### PR TITLE
Crear rol Administrador de los presupuestos participativos

### DIFF
--- a/app/assets/stylesheets/custom/_budget.scss
+++ b/app/assets/stylesheets/custom/_budget.scss
@@ -4,6 +4,12 @@
   .info {
     background: $dark-blue-gva;
   }
+
+  .callout.warning {
+    a {
+      color: $color-warning;
+    }
+  }
 }
 
 .budget-timeline {

--- a/app/controllers/custom/admin/base_controller.rb
+++ b/app/controllers/custom/admin/base_controller.rb
@@ -4,6 +4,6 @@ class Admin::BaseController < ApplicationController
   private
 
     def verify_administrator
-      raise CanCan::AccessDenied unless current_user&.administrator? || current_user&.legislator?
+      raise CanCan::AccessDenied unless current_user&.administrator? || current_user&.legislator? || current_user&.budget_manager?
     end
 end

--- a/app/controllers/custom/admin/budget_managers_controller.rb
+++ b/app/controllers/custom/admin/budget_managers_controller.rb
@@ -1,0 +1,26 @@
+class Admin::BudgetManagersController < Admin::BaseController
+  load_and_authorize_resource
+
+  def index
+    @budget_managers = @budget_managers.page(params[:page])
+  end
+
+  def search
+    @users = User.search(params[:name_or_email])
+                 .includes(:budget_manager)
+                 .page(params[:page])
+                 .for_render
+  end
+
+  def create
+    @budget_manager.user_id = params[:user_id]
+    @budget_manager.save!
+
+    redirect_to admin_budget_managers_path
+  end
+
+  def destroy
+    @budget_manager.destroy!
+    redirect_to admin_budget_managers_path
+  end
+end

--- a/app/controllers/custom/comments_controller.rb
+++ b/app/controllers/custom/comments_controller.rb
@@ -1,0 +1,17 @@
+require_dependency Rails.root.join("app", "controllers", "comments_controller").to_s
+
+class CommentsController
+  private
+
+  def check_for_special_comments
+    if administrator_comment?
+      if current_user.budget_manager?
+        @comment.budget_manager_id = current_user.budget_manager.id
+      else
+        @comment.administrator_id = current_user.administrator.id
+      end
+    elsif moderator_comment?
+      @comment.moderator_id = current_user.moderator.id
+    end
+  end
+end

--- a/app/controllers/custom/comments_controller.rb
+++ b/app/controllers/custom/comments_controller.rb
@@ -5,7 +5,9 @@ class CommentsController
 
   def check_for_special_comments
     if administrator_comment?
-      if current_user.budget_manager?
+      if current_user.legislator?
+        @comment.legislator_id = current_user.legislator.id
+      elsif current_user.budget_manager?
         @comment.budget_manager_id = current_user.budget_manager.id
       else
         @comment.administrator_id = current_user.administrator.id

--- a/app/controllers/custom/valuation/base_controller.rb
+++ b/app/controllers/custom/valuation/base_controller.rb
@@ -1,0 +1,9 @@
+require_dependency Rails.root.join("app", "controllers", "valuation", "base_controller").to_s
+
+class Valuation::BaseController < ApplicationController
+  private
+
+    def verify_valuator
+      raise CanCan::AccessDenied unless current_user&.valuator? || current_user&.administrator? || current_user&.budget_manager?
+    end
+end

--- a/app/controllers/custom/valuation/budget_investments_controller.rb
+++ b/app/controllers/custom/valuation/budget_investments_controller.rb
@@ -1,0 +1,19 @@
+require_dependency Rails.root.join("app", "controllers", "valuation", "budget_investments_controller").to_s
+
+class Valuation::BudgetInvestmentsController < Valuation::BaseController
+  private
+
+    def restrict_access
+      unless current_user.administrator? || current_user.budget_manager? || current_budget.valuating?
+        raise CanCan::AccessDenied.new(I18n.t("valuation.budget_investments.not_in_valuating_phase"))
+      end
+    end
+
+    def restrict_access_to_assigned_items
+      return if current_user.administrator? || current_user.budget_manager? ||
+                Budget::ValuatorAssignment.exists?(investment_id: params[:id],
+                                                   valuator_id: current_user.valuator.id)
+
+      raise ActionController::RoutingError.new("Not Found")
+    end
+end

--- a/app/helpers/custom/admin_helper.rb
+++ b/app/helpers/custom/admin_helper.rb
@@ -1,0 +1,9 @@
+module Custom::AdminHelper
+  def menu_budgets?
+    controller_name.starts_with?("budget") && controller_name != "budget_managers"
+  end
+
+  def menu_profiles?
+    %w[administrators organizations officials moderators valuators managers users legislators budget_managers].include?(controller_name)
+  end
+end

--- a/app/helpers/custom/users_helper.rb
+++ b/app/helpers/custom/users_helper.rb
@@ -3,6 +3,10 @@ module Custom::UsersHelper
     current_user&.legislator?
   end
 
+  def current_budget_manager?
+    current_user&.budget_manager?
+  end
+
   def special_verification_reason(user)
     text = []
     text << t("admin.users.columns.residence_requested_reasons.foreign_residence") if user.residence_requested_foreign?

--- a/app/models/custom/abilities/budget_manager.rb
+++ b/app/models/custom/abilities/budget_manager.rb
@@ -7,17 +7,15 @@ module Abilities
 
       can :comment_as_administrator, [Budget::Investment]
 
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
-      can [:read, :create, :update, :destroy], Budget::Group
-      can [:read, :create, :update, :destroy], Budget::Heading
+      can [:index, :read], Budget
+      can [:read], Budget::Group
+      can [:read], Budget::Heading
       can [:hide, :admin_update, :toggle_selection], Budget::Investment
       can [:valuate, :comment_valuation], Budget::Investment
       cannot [:admin_update, :toggle_selection, :valuate, :comment_valuation],
         Budget::Investment, budget: { phase: "finished" }
 
       can :create, Budget::ValuatorAssignment
-
-      can :read_admin_stats, Budget, &:balloting_or_later?
     end
   end
 end

--- a/app/models/custom/abilities/budget_manager.rb
+++ b/app/models/custom/abilities/budget_manager.rb
@@ -3,6 +3,8 @@ module Abilities
     include CanCan::Ability
 
     def initialize(user)
+      merge Abilities::Common.new(user)
+
       can :comment_as_administrator, [Budget::Investment]
 
       can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget

--- a/app/models/custom/abilities/budget_manager.rb
+++ b/app/models/custom/abilities/budget_manager.rb
@@ -1,0 +1,21 @@
+module Abilities
+  class BudgetManager
+    include CanCan::Ability
+
+    def initialize(user)
+      can :comment_as_administrator, [Budget::Investment]
+
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
+      can [:read, :create, :update, :destroy], Budget::Group
+      can [:read, :create, :update, :destroy], Budget::Heading
+      can [:hide, :admin_update, :toggle_selection], Budget::Investment
+      can [:valuate, :comment_valuation], Budget::Investment
+      cannot [:admin_update, :toggle_selection, :valuate, :comment_valuation],
+        Budget::Investment, budget: { phase: "finished" }
+
+      can :create, Budget::ValuatorAssignment
+
+      can :read_admin_stats, Budget, &:balloting_or_later?
+    end
+  end
+end

--- a/app/models/custom/abilities/legislator.rb
+++ b/app/models/custom/abilities/legislator.rb
@@ -3,6 +3,8 @@ module Abilities
     include CanCan::Ability
 
     def initialize(user)
+      merge Abilities::Common.new(user)
+
       can :create, Legislation::Proposal
       can :show, Legislation::Proposal
       can :proposals, ::Legislation::Process

--- a/app/models/custom/ability.rb
+++ b/app/models/custom/ability.rb
@@ -13,8 +13,11 @@ class Ability
         merge Abilities::Administrator.new(user)
         can [:manage], ::Milestone::Status
         can [:manage], ::Legislator
+        can [:manage], ::BudgetManager
       elsif user.legislator?
         merge Abilities::Legislator.new(user)
+      elsif user.budget_manager?
+        merge Abilities::BudgetManager.new(user)
       elsif user.moderator?
         merge Abilities::Moderator.new(user)
       elsif user.manager?

--- a/app/models/custom/budget_manager.rb
+++ b/app/models/custom/budget_manager.rb
@@ -1,0 +1,16 @@
+class BudgetManager < ApplicationRecord
+  belongs_to :user, touch: true
+  delegate :name, :email, :name_and_email, to: :user
+
+  validates :user_id, presence: true, uniqueness: true
+
+  scope :with_user, -> { includes(:user) }
+
+  def description_or_name
+    description.presence || name
+  end
+
+  def description_or_name_and_email
+    "#{description_or_name} (#{email})"
+  end
+end

--- a/app/models/custom/comment.rb
+++ b/app/models/custom/comment.rb
@@ -1,0 +1,11 @@
+require_dependency Rails.root.join("app", "models", "comment").to_s
+
+class Comment
+  scope :not_as_admin_or_moderator, -> do
+    where("administrator_id IS NULL OR budget_manager_id IS NULL").where("moderator_id IS NULL")
+  end
+
+  def as_administrator?
+    administrator_id.present? || budget_manager_id.present?
+  end
+end

--- a/app/models/custom/comment.rb
+++ b/app/models/custom/comment.rb
@@ -2,10 +2,10 @@ require_dependency Rails.root.join("app", "models", "comment").to_s
 
 class Comment
   scope :not_as_admin_or_moderator, -> do
-    where("administrator_id IS NULL OR budget_manager_id IS NULL").where("moderator_id IS NULL")
+    where("administrator_id IS NULL OR legislator_id IS NULL OR budget_manager_id IS NULL").where("moderator_id IS NULL")
   end
 
   def as_administrator?
-    administrator_id.present? || budget_manager_id.present?
+    administrator_id.present? || legislator_id.present? || budget_manager_id.present?
   end
 end

--- a/app/models/custom/user.rb
+++ b/app/models/custom/user.rb
@@ -2,19 +2,25 @@ require_dependency Rails.root.join("app", "models", "user").to_s
 
 class User
   has_one :legislator
+  has_one :budget_manager
   has_many :legislation_processes, inverse_of: :user
 
   scope :residence_requested, -> { where.not(residence_requested_at: nil).where(residence_verified_at: nil) }
   scope :legislators, -> { joins(:legislator) }
+  scope :budget_managers, -> { joins(:budget_manager) }
   scope :other, -> { where(gender: "other") }
 
   def legislator?
     legislator.present?
   end
 
+  def budget_manager?
+    budget_manager.present?
+  end
+
   def show_welcome_screen?
     verification = Setting["feature.user.skip_verification"].present? ? true : unverified?
-    sign_in_count == 1 && verification && !organization && !administrator? && !legislator?
+    sign_in_count == 1 && verification && !organization && !administrator? && !legislator? && !budget_manager?
   end
 
   def self.soft_minimum_required_age

--- a/app/views/custom/admin/_admin_menu.html.erb
+++ b/app/views/custom/admin/_admin_menu.html.erb
@@ -190,7 +190,7 @@
       <span class="icon-organizations"></span>
       <strong><%= t("admin.menu.title_profiles") %></strong>
     </a>
-    <ul <%= "class=is-active" if menu_profiles? || controller_name == "legislators" %>>
+    <ul <%= "class=is-active" if menu_profiles? %>>
       <li <%= "class=is-active" if controller_name == "administrators" %>>
         <%= link_to t("admin.menu.administrators"), admin_administrators_path %>
       </li>
@@ -217,6 +217,10 @@
 
       <li <%= "class=is-active" if controller_name == "legislators" %>>
         <%= link_to t("admin.menu.legislators"), admin_legislators_path %>
+      </li>
+
+      <li <%= "class=is-active" if controller_name == "budget_managers" %>>
+        <%= link_to t("admin.menu.budget_managers"), admin_budget_managers_path %>
       </li>
 
       <li <%= "class=is-active" if controller_name == "users" %>>

--- a/app/views/custom/admin/_budget_manager_menu.html.erb
+++ b/app/views/custom/admin/_budget_manager_menu.html.erb
@@ -1,0 +1,10 @@
+<ul id="legislation_menu" data-accordion-menu data-multi-open="true">
+  <% if feature?(:budgets) %>
+    <li class="section-title <%= "is-active" if menu_budgets? %>">
+      <%= link_to admin_budgets_path do %>
+        <span class="icon-budget"></span>
+        <strong><%= t("admin.menu.budgets") %></strong>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/custom/admin/_menu.html.erb
+++ b/app/views/custom/admin/_menu.html.erb
@@ -1,5 +1,7 @@
 <% if current_user.legislator? %>
   <%= render 'admin/legislation_menu' %>
+<% elsif current_user.budget_manager? %>
+  <%= render 'admin/budget_manager_menu' %>
 <% else %>
   <%= render 'admin/admin_menu' %>
 <% end %>

--- a/app/views/custom/admin/budget_managers/index.html.erb
+++ b/app/views/custom/admin/budget_managers/index.html.erb
@@ -1,0 +1,41 @@
+<h2><%= t("admin.budget_managers.index.title") %></h2>
+
+<%= render "admin/shared/user_search", url: search_admin_budget_managers_path %>
+
+<div id="budget_managers">
+  <% if @budget_managers.any? %>
+    <h3 class="margin"><%= page_entries_info @budget_managers %></h3>
+
+    <table>
+      <thead>
+        <th scope="col"><%= t("admin.budget_managers.index.name") %></th>
+        <th scope="col"><%= t("admin.budget_managers.index.email") %></th>
+        <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
+      </thead>
+      <tbody>
+        <% @budget_managers.each do |budget_manager| %>
+          <tr>
+            <td>
+              <%= budget_manager.name %>
+            </td>
+            <td>
+              <%= budget_manager.email %>
+            </td>
+            <td>
+              <%= link_to t("admin.budget_managers.budget_manager.delete"),
+                admin_budget_manager_path(budget_manager),
+                method: :delete,
+                class: "button hollow alert expanded" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= paginate @budget_managers %>
+  <% else %>
+    <div class="callout primary">
+      <%= t("admin.budget_managers.index.no_budget_managers") %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/custom/admin/budget_managers/search.html.erb
+++ b/app/views/custom/admin/budget_managers/search.html.erb
@@ -1,0 +1,44 @@
+<h2><%= t("admin.budget_managers.search.title") %></h2>
+
+<%= render "admin/shared/user_search", url: search_admin_budget_managers_path %>
+
+<div id="budget_managers">
+  <% if @users.any? %>
+    <h3><%= page_entries_info @users %></h3>
+
+    <table>
+      <thead>
+        <th scope="col"><%= t("admin.budget_managers.index.name") %></th>
+        <th scope="col"><%= t("admin.budget_managers.index.email") %></th>
+        <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
+      </thead>
+      <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.name %></td>
+          <td><%= user.email %></td>
+          <td>
+            <% if user.budget_manager? && user.budget_manager.persisted? %>
+              <%= link_to t("admin.budget_managers.budget_manager.delete"),
+                          admin_budget_manager_path(user.budget_manager),
+                          method: :delete,
+                          class: "button hollow alert expanded" %>
+            <% else %>
+              <%= link_to t("admin.budget_managers.budget_manager.add"),
+                          { controller: "admin/budget_managers",
+                            action: :create,
+                            user_id: user },
+                          method: :post,
+                          class: "button success expanded" %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="callout alert margin">
+      <%= t("admin.shared.no_search_results") %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/custom/admin/budgets/index.html.erb
+++ b/app/views/custom/admin/budgets/index.html.erb
@@ -1,0 +1,74 @@
+<h2 class="inline-block"><%= t("admin.budgets.index.title") %></h2>
+
+<% if current_ability.can? :new, Budget %>
+  <%= link_to t("admin.budgets.index.new_link"),
+              new_admin_budget_path,
+              class: "button float-right" %>
+<% end %>
+
+<%= render "shared/filter_subnav", i18n_namespace: "admin.budgets.index" %>
+
+<% if @budgets.any? %>
+  <h3><%= page_entries_info @budgets %></h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("admin.budgets.index.table_name") %></th>
+        <th><%= t("admin.budgets.index.table_phase") %></th>
+        <th><%= t("admin.budgets.index.table_investments") %></th>
+        <% if current_ability.can? :edit, Budget::Group %>
+          <th><%= t("admin.budgets.index.table_edit_groups") %></th>
+        <% end %>
+        <% if current_ability.can? :edit, Budget %>
+          <th><%= t("admin.budgets.index.table_edit_budget") %></th>
+        <% end %>
+        <% if current_ability.can? :create, Poll %>
+          <th><%= t("admin.budgets.index.table_admin_ballots") %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @budgets.each do |budget| %>
+        <tr id="<%= dom_id(budget) %>" class="budget">
+          <td>
+            <%= budget.name %>
+          </td>
+          <td class="small">
+            <%= t("budgets.phase.#{budget.phase}") %>
+          </td>
+          <td>
+            <%= link_to t("admin.budgets.index.budget_investments"),
+                           admin_budget_budget_investments_path(budget_id: budget.id),
+                           class: "button hollow medium" %>
+          </td>
+          <% if current_ability.can? :edit, Budget::Group %>
+            <td class="small">
+              <%= link_to t("admin.budgets.index.edit_groups"), admin_budget_groups_path(budget) %>
+            </td>
+          <% end %>
+          <% if current_ability.can? :edit, budget %>
+            <td class="small">
+              <%= link_to t("admin.budgets.index.edit_budget"), edit_admin_budget_path(budget) %>
+            </td>
+          <% end %>
+          <% if current_ability.can? :create, Poll %>
+            <td class="small">
+              <% if budget.poll.present? %>
+                <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_booth_assignments_path(budget.poll) %>
+              <% else %>
+                <%= link_to_create_budget_poll(budget) %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @budgets %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.budgets.index.no_budgets") %>
+  </div>
+<% end %>

--- a/app/views/custom/comments/_comment.html.erb
+++ b/app/views/custom/comments/_comment.html.erb
@@ -1,0 +1,122 @@
+<% valuation = local_assigns.fetch(:valuation, false) %>
+<% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author] do %>
+  <div id="<%= dom_id(comment) %>" class="comment small-12">
+    <div class="comment-body">
+      <% if comment.hidden? || comment.user.hidden? %>
+        <% if comment.children.size > 0 %>
+          <div class="callout secondary">
+            <p><%= t("comments.comment.deleted") %></p>
+          </div>
+        <% end %>
+      <% else %>
+        <% if comment.as_administrator? %>
+          <%= image_tag("avatar_admin.png", size: 32, class: "admin-avatar float-left") %>
+        <% elsif comment.as_moderator? %>
+          <%= image_tag("avatar_moderator.png", size: 32, class: "moderator-avatar float-left") %>
+        <% else %>
+        <% if comment.user.hidden? || comment.user.erased? %>
+            <span class="icon-deleted user-deleted"></span>
+          <% elsif comment.user.organization? %>
+            <%= image_tag("avatar_collective.png", size: 32, class: "avatar float-left") %>
+          <% else %>
+            <%= avatar_image(comment.user, seed: comment.user_id, size: 32, class: "float-left") %>
+          <% end %>
+        <% end %>
+
+        <div class="comment-info">
+
+          <% if comment.as_administrator? %>
+            <span class="user-name">
+              <% if comment.administrator_id.present? %>
+                <%= t("comments.comment.admin") %>
+                <% if valuation %>
+                  <%= Administrator.find(comment.administrator_id).description_or_name %>
+                <% else %>
+                  #<%= comment.administrator_id %>
+                <% end %>
+              <% elsif comment.budget_manager_id.present? %>
+                <%= t("comments.comment.budget_manager") %>
+                <% if valuation %>
+                  <%= BudgetManager.find(comment.budget_manager_id).description_or_name %>
+                <% else %>
+                  #<%= comment.budget_manager_id %>
+                <% end %>
+              <% end %>
+            </span>
+          <% elsif comment.as_moderator? %>
+            <span class="user-name"><%= t("comments.comment.moderator") %> #<%= comment.moderator_id %></span>
+          <% else %>
+
+            <% if comment.user.hidden? || comment.user.erased? %>
+              <span class="user-name"><%= t("comments.comment.user_deleted") %></span>
+            <% else %>
+              <span class="user-name"><%= link_to comment.user.name, user_path(comment.user) %></span>
+              <% if comment.user.display_official_position_badge? %>
+                &nbsp;&bull;&nbsp;
+                <span class="label round level-<%= comment.user.official_level %>">
+                  <%= comment.user.official_position %>
+                </span>
+              <% end %>
+            <% end %>
+            <% if comment.user.verified_organization? %>
+              &nbsp;&bull;&nbsp;
+              <span class="label round is-association">
+                <%= t("shared.collective") %>
+              </span>
+            <% end %>
+            <% if comment.user_id == comment.commentable.author_id %>
+              &nbsp;&bull;&nbsp;
+              <span class="label round is-author">
+                <%= t("comments.comment.author") %>
+              </span>
+            <% end %>
+
+          <% end %>
+
+          &nbsp;&bull;&nbsp;
+          <span>
+            <%= link_to comment_path(comment) do %>
+              <%= l comment.created_at.to_datetime, format: :datetime %>
+            <% end %>
+          </span>
+        </div>
+
+        <div class="comment-user
+                  <%= user_level_class comment %>
+                  <%= comment_author_class comment, comment.commentable.author_id %>">
+          <%= simple_format sanitize_and_auto_link(comment.body), {}, sanitize: false %>
+        </div>
+
+        <div id="<%= dom_id(comment) %>_reply" class="reply">
+          <% unless valuation %>
+            <div id="<%= dom_id(comment) %>_votes" class="comment-votes float-right">
+              <%= render "comments/votes", comment: comment %>
+            </div>
+          <% end %>
+
+          <span class="responses-count">
+            <%= render "comments/responses_count", count: comment.children.size %>
+          </span>
+
+          <% if user_signed_in? && !comments_closed_for_commentable?(comment.commentable) && !require_verified_resident_for_commentable?(comment.commentable, current_user) %>
+            <span class="divider">&nbsp;|&nbsp;</span>
+            <%= link_to(comment_link_text(comment), "",
+                        class: "js-add-comment-link", data: { "id": dom_id(comment) }) %>
+
+            <% unless valuation %>
+              <%= render "comments/actions", { comment: comment } %>
+            <% end %>
+
+            <% if !valuation || can?(:comment_valuation, comment.commentable) %>
+              <%= render "comments/form", { commentable: comment.commentable,
+                                           parent_id: comment.id,
+                                           valuation: valuation } %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= render "comments/comment_list", comments: child_comments_of(comment), valuation: valuation %>
+  </div>
+<% end %>

--- a/app/views/custom/comments/_comment.html.erb
+++ b/app/views/custom/comments/_comment.html.erb
@@ -27,12 +27,12 @@
 
           <% if comment.as_administrator? %>
             <span class="user-name">
-              <% if comment.administrator_id.present? %>
-                <%= t("comments.comment.admin") %>
+              <% if comment.legislator_id.present? %>
+                <%= t("comments.comment.legislator") %>
                 <% if valuation %>
-                  <%= Administrator.find(comment.administrator_id).description_or_name %>
+                  <%= Legislator.find(comment.legislator_id).description_or_name %>
                 <% else %>
-                  #<%= comment.administrator_id %>
+                  #<%= comment.legislator_id %>
                 <% end %>
               <% elsif comment.budget_manager_id.present? %>
                 <%= t("comments.comment.budget_manager") %>
@@ -40,6 +40,13 @@
                   <%= BudgetManager.find(comment.budget_manager_id).description_or_name %>
                 <% else %>
                   #<%= comment.budget_manager_id %>
+                <% end %>
+              <% else %>
+                <%= t("comments.comment.admin") %>
+                <% if valuation %>
+                  <%= Administrator.find(comment.administrator_id).description_or_name %>
+                <% else %>
+                  #<%= comment.administrator_id %>
                 <% end %>
               <% end %>
             </span>

--- a/app/views/custom/layouts/_admin_header.html.erb
+++ b/app/views/custom/layouts/_admin_header.html.erb
@@ -30,14 +30,16 @@
               <h1>
                 <%= link_to namespaced_root_path do %>
                   <%= setting["org_name"] %>
-                  <br><small><%= t("admin.legislators.header.title") %></small>
+                  <br><small><%= t("admin.legislators.header.title") %> - </small>
+                  <small><%= namespaced_header_title %></small>
                 <% end %>
               </h1>
             <% elsif current_budget_manager? %>
               <h1>
                 <%= link_to namespaced_root_path do %>
                   <%= setting["org_name"] %>
-                  <br><small><%= t("admin.budget_managers.header.title") %></small>
+                  <br><small><%= t("admin.budget_managers.header.title") %> - </small>
+                  <small><%= namespaced_header_title %></small>
                 <% end %>
               </h1>
             <% else %>

--- a/app/views/custom/layouts/_admin_header.html.erb
+++ b/app/views/custom/layouts/_admin_header.html.erb
@@ -33,6 +33,13 @@
                   <br><small><%= t("admin.legislators.header.title") %></small>
                 <% end %>
               </h1>
+            <% elsif current_budget_manager? %>
+              <h1>
+                <%= link_to namespaced_root_path do %>
+                  <%= setting["org_name"] %>
+                  <br><small><%= t("admin.budget_managers.header.title") %></small>
+                <% end %>
+              </h1>
             <% else %>
               <h1>
                 <%= link_to namespaced_root_path do %>

--- a/app/views/custom/shared/_admin_login_items.html.erb
+++ b/app/views/custom/shared/_admin_login_items.html.erb
@@ -1,4 +1,4 @@
-<% if show_admin_menu?(current_user) || current_user&.legislator? %>
+<% if show_admin_menu?(current_user) || current_user&.legislator? || current_user&.budget_manager? %>
   <li class="has-submenu">
     <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
     <ul class="submenu menu vertical" data-submenu>
@@ -36,6 +36,12 @@
       <% if current_user.legislator? %>
         <li>
           <%= link_to t("layouts.header.legislation"), admin_legislation_processes_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.budget_manager? %>
+        <li>
+          <%= link_to t("layouts.header.budget_management"), admin_budgets_path %>
         </li>
       <% end %>
     </ul>

--- a/app/views/custom/shared/_admin_login_items.html.erb
+++ b/app/views/custom/shared/_admin_login_items.html.erb
@@ -8,6 +8,18 @@
         </li>
       <% end %>
 
+      <% if current_user.legislator? %>
+        <li>
+          <%= link_to t("layouts.header.administration"), admin_legislation_processes_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.budget_manager? %>
+        <li>
+          <%= link_to t("layouts.header.administration"), admin_budgets_path %>
+        </li>
+      <% end %>
+
       <% if current_user.administrator? || current_user.moderator? %>
         <li>
           <%= link_to t("layouts.header.moderation"), moderation_root_path %>
@@ -15,7 +27,7 @@
       <% end %>
 
       <% if feature?(:budgets) &&
-            (current_user.administrator? || current_user.valuator?) %>
+            (current_user.administrator? || current_user.valuator? || current_user.budget_manager?) %>
         <li>
           <%= link_to t("layouts.header.valuation"), valuation_root_path %>
         </li>
@@ -30,18 +42,6 @@
       <% if current_user.poll_officer? && Poll.current.any? %>
         <li>
           <%= link_to t("layouts.header.officing"), officing_root_path %>
-        </li>
-      <% end %>
-
-      <% if current_user.legislator? %>
-        <li>
-          <%= link_to t("layouts.header.legislation"), admin_legislation_processes_path %>
-        </li>
-      <% end %>
-
-      <% if current_user.budget_manager? %>
-        <li>
-          <%= link_to t("layouts.header.budget_management"), admin_budgets_path %>
         </li>
       <% end %>
     </ul>

--- a/config/locales/custom/es/budget_managers.yml
+++ b/config/locales/custom/es/budget_managers.yml
@@ -2,24 +2,27 @@ es:
   activerecord:
     models:
       budget_manager:
-        one: "Administrador de presupuestos"
-        other: "Administradores de presupuestos"
+        one: "Administrador de presupuestos participativos"
+        other: "Administradores de presupuestos participativos"
   layouts:
     header:
       budget_management: Presupuestos
   admin:
     menu:
-      budget_managers: Administradores de presupuestos
+      budget_managers: Administradores de presupuestos participativos
     budget_managers:
       header:
         title: Presupuestos participativos
       index:
-        title: Administradores de presupuestos
+        title: Administradores de presupuestos participativos
         name: Nombre
         email: Email
-        no_budget_managers: No hay administradores de presupuestos.
+        no_budget_managers: No hay administradores de presupuestos participativos.
       budget_manager:
-        add: Añadir como administrador de presupuestos
+        add: Añadir como administrador de presupuestos participativos
         delete: Borrar
       search:
-        title: "Administradores de presupuestos: Búsqueda de usuarios"
+        title: "Administradores de presupuestos participativos: Búsqueda de usuarios"
+  comments:
+    comment:
+      budget_manager: Administrador de presupuestos participativos

--- a/config/locales/custom/es/budget_managers.yml
+++ b/config/locales/custom/es/budget_managers.yml
@@ -2,27 +2,27 @@ es:
   activerecord:
     models:
       budget_manager:
-        one: "Administrador de presupuestos participativos"
-        other: "Administradores de presupuestos participativos"
+        one: "Administrador de los presupuestos participativos"
+        other: "Administradores de los presupuestos participativos"
   layouts:
     header:
       budget_management: Presupuestos
   admin:
     menu:
-      budget_managers: Administradores de presupuestos participativos
+      budget_managers: Administradores de los presupuestos
     budget_managers:
       header:
         title: Presupuestos participativos
       index:
-        title: Administradores de presupuestos participativos
+        title: Administradores de los presupuestos participativos
         name: Nombre
         email: Email
-        no_budget_managers: No hay administradores de presupuestos participativos.
+        no_budget_managers: No hay administradores de los presupuestos participativos.
       budget_manager:
-        add: Añadir como administrador de presupuestos participativos
+        add: Añadir como administrador de los presupuestos participativos
         delete: Borrar
       search:
-        title: "Administradores de presupuestos participativos: Búsqueda de usuarios"
+        title: "Administradores de los presupuestos participativos: Búsqueda de usuarios"
   comments:
     comment:
-      budget_manager: Administrador de presupuestos participativos
+      budget_manager: Administrador de los presupuestos participativos

--- a/config/locales/custom/es/budget_managers.yml
+++ b/config/locales/custom/es/budget_managers.yml
@@ -6,7 +6,7 @@ es:
         other: "Administradores de presupuestos"
   layouts:
     header:
-      budget_management: Administrar presupuestos
+      budget_management: Presupuestos
   admin:
     menu:
       budget_managers: Administradores de presupuestos

--- a/config/locales/custom/es/budget_managers.yml
+++ b/config/locales/custom/es/budget_managers.yml
@@ -4,9 +4,6 @@ es:
       budget_manager:
         one: "Administrador de los presupuestos participativos"
         other: "Administradores de los presupuestos participativos"
-  layouts:
-    header:
-      budget_management: Presupuestos
   admin:
     menu:
       budget_managers: Administradores de los presupuestos

--- a/config/locales/custom/es/budget_managers.yml
+++ b/config/locales/custom/es/budget_managers.yml
@@ -1,0 +1,25 @@
+es:
+  activerecord:
+    models:
+      budget_manager:
+        one: "Administrador de presupuestos"
+        other: "Administradores de presupuestos"
+  layouts:
+    header:
+      budget_management: Administrar presupuestos
+  admin:
+    menu:
+      budget_managers: Administradores de presupuestos
+    budget_managers:
+      header:
+        title: Presupuestos participativos
+      index:
+        title: Administradores de presupuestos
+        name: Nombre
+        email: Email
+        no_budget_managers: No hay administradores de presupuestos.
+      budget_manager:
+        add: Añadir como administrador de presupuestos
+        delete: Borrar
+      search:
+        title: "Administradores de presupuestos: Búsqueda de usuarios"

--- a/config/locales/custom/es/legislators.yml
+++ b/config/locales/custom/es/legislators.yml
@@ -4,9 +4,6 @@ es:
       legislator:
         one: "Legislador"
         other: "Legisladores"
-  layouts:
-    header:
-      legislation: Elaboración normativa
   admin:
     menu:
       legislators: Legisladores
@@ -25,4 +22,4 @@ es:
         title: "Legisladores: Búsqueda de usuarios"
   comments:
     comment:
-      legislator: Legislador
+      legislator: Administrador legislador

--- a/config/locales/custom/es/legislators.yml
+++ b/config/locales/custom/es/legislators.yml
@@ -23,3 +23,6 @@ es:
         delete: Borrar
       search:
         title: "Legisladores: Búsqueda de usuarios"
+  comments:
+    comment:
+      legislator: Legislador

--- a/config/locales/custom/es/verification.yml
+++ b/config/locales/custom/es/verification.yml
@@ -63,6 +63,7 @@ es:
         document_type_label: Tipo de documento
         date_of_birth: Fecha de nacimiento
         invalid_date_of_birth: La fecha de nacimiento no coincide
+        invalid_postal_code: El código postal no coincide
         gender_label: Género
         not_verified: No verificada
         postal_code: Código postal

--- a/config/locales/custom/val/budget_managers.yml
+++ b/config/locales/custom/val/budget_managers.yml
@@ -1,0 +1,25 @@
+es:
+  activerecord:
+    models:
+      budget_manager:
+        one: "Administrador de los presupuestos participativos"
+        other: "Administradores de los presupuestos participativos"
+  admin:
+    menu:
+      budget_managers: Administradores de los presupuestos
+    budget_managers:
+      header:
+        title: Presupuestos participativos
+      index:
+        title: Administradores de los presupuestos participativos
+        name: Nombre
+        email: Email
+        no_budget_managers: No hay administradores de los presupuestos participativos.
+      budget_manager:
+        add: Añadir como administrador de los presupuestos participativos
+        delete: Borrar
+      search:
+        title: "Administradores de los presupuestos participativos: Búsqueda de usuarios"
+  comments:
+    comment:
+      budget_manager: Administrador de los presupuestos participativos

--- a/config/locales/custom/val/legislators.yml
+++ b/config/locales/custom/val/legislators.yml
@@ -1,0 +1,25 @@
+es:
+  activerecord:
+    models:
+      legislator:
+        one: "Legislador"
+        other: "Legisladores"
+  admin:
+    menu:
+      legislators: Legisladores
+    legislators:
+      header:
+        title: Elaboración normativa
+      index:
+        title: Legisladores
+        name: Nombre
+        email: Email
+        no_legislators: No hay legisladores.
+      legislator:
+        add: Añadir como legislador
+        delete: Borrar
+      search:
+        title: "Legisladores: Búsqueda de usuarios"
+  comments:
+    comment:
+      legislator: Administrador legislador

--- a/config/locales/custom/val/verification.yml
+++ b/config/locales/custom/val/verification.yml
@@ -63,6 +63,7 @@ val:
         document_type_label: Tipus de document
         date_of_birth: Data de naixement
         invalid_date_of_birth: La data de naixement no coincideix
+        invalid_postal_code: El codi postal no coincideix
         gender_label: Gènere
         postal_code: Codi postal
         name: Nom

--- a/config/routes/custom_routes.rb
+++ b/config/routes/custom_routes.rb
@@ -2,4 +2,7 @@ namespace :admin do
   resources :legislators, only: [:index, :create, :destroy] do
     get :search, on: :collection
   end
+  resources :budget_managers, only: [:index, :create, :destroy] do
+    get :search, on: :collection
+  end
 end

--- a/db/migrate/20210426093818_create_budget_managers.rb
+++ b/db/migrate/20210426093818_create_budget_managers.rb
@@ -1,0 +1,8 @@
+class CreateBudgetManagers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :budget_managers do |t|
+      t.belongs_to :user, index: true, foreign_key: true
+      t.string :description
+    end
+  end
+end

--- a/db/migrate/20210426120920_add_budget_manager_id_to_comments.rb
+++ b/db/migrate/20210426120920_add_budget_manager_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddBudgetManagerIdToComments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comments, :budget_manager_id, :integer
+  end
+end

--- a/db/migrate/20210426125854_add_legislator_id_to_comments.rb
+++ b/db/migrate/20210426125854_add_legislator_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddLegislatorIdToComments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :comments, :legislator_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210426120920) do
+ActiveRecord::Schema.define(version: 20210426125854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -420,6 +420,7 @@ ActiveRecord::Schema.define(version: 20210426120920) do
     t.integer "confidence_score", default: 0, null: false
     t.boolean "valuation", default: false
     t.integer "budget_manager_id"
+    t.integer "legislator_id"
     t.index ["ancestry"], name: "index_comments_on_ancestry"
     t.index ["cached_votes_down"], name: "index_comments_on_cached_votes_down"
     t.index ["cached_votes_total"], name: "index_comments_on_cached_votes_total"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210414160324) do
+ActiveRecord::Schema.define(version: 20210426093818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -277,6 +277,12 @@ ActiveRecord::Schema.define(version: 20210414160324) do
     t.index ["community_id"], name: "index_budget_investments_on_community_id"
     t.index ["heading_id"], name: "index_budget_investments_on_heading_id"
     t.index ["tsv"], name: "index_budget_investments_on_tsv", using: :gin
+  end
+
+  create_table "budget_managers", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "description"
+    t.index ["user_id"], name: "index_budget_managers_on_user_id"
   end
 
   create_table "budget_phase_translations", id: :serial, force: :cascade do |t|
@@ -1620,6 +1626,7 @@ ActiveRecord::Schema.define(version: 20210414160324) do
   add_foreign_key "budget_administrators", "administrators"
   add_foreign_key "budget_administrators", "budgets"
   add_foreign_key "budget_investments", "communities"
+  add_foreign_key "budget_managers", "users"
   add_foreign_key "budget_valuators", "budgets"
   add_foreign_key "budget_valuators", "valuators"
   add_foreign_key "dashboard_administrator_tasks", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210426093818) do
+ActiveRecord::Schema.define(version: 20210426120920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -419,6 +419,7 @@ ActiveRecord::Schema.define(version: 20210426093818) do
     t.string "ancestry"
     t.integer "confidence_score", default: 0, null: false
     t.boolean "valuation", default: false
+    t.integer "budget_manager_id"
     t.index ["ancestry"], name: "index_comments_on_ancestry"
     t.index ["cached_votes_down"], name: "index_comments_on_cached_votes_down"
     t.index ["cached_votes_total"], name: "index_comments_on_cached_votes_total"


### PR DESCRIPTION
Agrega el rol "Administrador de los presupuestos participativos" a la aplicación. Este rol actúa como un administrador, pero sólo puede gestionar el área de "Presupuestos participativos". Este rol puede generar informes de evaluación incluso si no es un evaluador, de la misma forma que puede hacerlo un administrador convencional.

Se añade una pantalla para gestionar los administradores de los presupuestos participativos de la aplicación dentro de la sección "Perfiles". Esta pantalla sigue el funcionamiento ya existente para gestionar administradores, gestores y otros roles de la aplicación.

Se corrigen bugs relacionados con el rol "Legislador" y la capacidad de comentar como administrador.

Se añaden los ficheros de traducciones de este rol y del rol "Legislador", con el contenido en español de forma temporal.