### PR TITLE
Evitar que Turbolinks intercepte las peticiones AJAX del contador de personas registradas

### DIFF
--- a/app/assets/javascripts/custom/welcome_counter.js
+++ b/app/assets/javascripts/custom/welcome_counter.js
@@ -26,15 +26,17 @@ class WelcomeCounter {
   }
 
   countFetch() {
-    fetch('/users_count.json')
-      .then(function(response) { return response.json(); })
-      .then(function(data) {
+    $.ajax({
+      url: '/users_count.json',
+      dataType: 'json',
+      success: function(data) {
         if (data.count > this.countTo) {
           clearInterval(this.countFetchInterval);
           this.countTo = data.count;
           this.countInterval = setInterval(this.countUp.bind(this), 10);
         }
-      }.bind(this));
+      }.bind(this)
+    });
   }
 
   random(min, max) {


### PR DESCRIPTION
Al iniciar sesión, Turbolinks intercepta la petición AJAX del contador de usuarios y la toma como a la URL que debe volver:
![image](https://user-images.githubusercontent.com/5518916/116386551-cd777300-a811-11eb-8102-491009473121.png)

Se modifica la llamada AJAX para utilizar jQuery.ajax, lo cual no es interceptado por Turbolinks.
