### PR TITLE
Arreglar filtro de ordenación de comentarios

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -6,3 +6,4 @@
 //
 
 //= require welcome_counter
+//= require select_local

--- a/app/assets/javascripts/custom/select_local.js
+++ b/app/assets/javascripts/custom/select_local.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', function(event) {
+  $("input[type=radio][name=select-local]").on("change", function () {
+    window.location.assign($(this).val());
+  });
+});

--- a/app/assets/javascripts/location_changer.js
+++ b/app/assets/javascripts/location_changer.js
@@ -1,10 +1,10 @@
-(function () {
+(function() {
   "use strict";
   App.LocationChanger = {
-    initialize: function () {
-      $("input[type=radio][name=select-local]").on("change", function () {
+    initialize: function() {
+      $(".js-location-changer").on("change", function() {
         window.location.assign($(this).val());
       });
-    },
+    }
   };
-}.call(this));
+}).call(this);


### PR DESCRIPTION
Arregla el filtro de ordenación de comentarios "Ordenar por", el cual no hacía nada al seleccionar la opción.
![image](https://user-images.githubusercontent.com/5518916/118146710-cb630600-b406-11eb-8f2b-bbe526a80ed4.png)
