### PR TITLE
Desactivar el banner de la sección de propuestas

### DIFF
--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -49,8 +49,6 @@
   <div class="row">
     <div id="proposals" class="proposals-list small-12 medium-9 column">
 
-      <%= render 'shared/alert', title: t('go_to_budgets.title'), description: t('go_to_budgets.description'), url_text: t('go_to_budgets.url_text'), color: '#ffdc5c', url: budgets_path %>
-
       <%= render "shared/banner" %>
 
       <% if show_featured_proposals? %>

--- a/app/views/custom/proposals/new.html.erb
+++ b/app/views/custom/proposals/new.html.erb
@@ -1,7 +1,6 @@
 <div class="proposal-form row">
 
   <div class="small-12 medium-9 column">
-    <%= render 'shared/alert', title: t('go_to_budgets.title'), description: t('go_to_budgets.description'), url_text: t('go_to_budgets.url_text'), url: budgets_path, color: '#ffdc5c', modal: true %>
 
     <%= back_link_to %>
 


### PR DESCRIPTION
Elimina el mensaje de alerta y el popup de la sección de propuestas, en el listado y en el formulario de creación de propuesta.