### PR TITLE
fix: Filename broken when document title changed

### DIFF
--- a/app/helpers/custom/documents_helper.rb
+++ b/app/helpers/custom/documents_helper.rb
@@ -1,0 +1,12 @@
+module Custom::DocumentsHelper
+  def fixed_document_item_link(document)
+    info_text = "#{document.humanized_content_type} | #{number_to_human_size(document.attachment_file_size)}"
+
+    document.fix_attachment_path if !File.exist?(document.attachment.path)
+
+    link_to safe_join([document.title, tag.small("(#{info_text})")], " "),
+            document.attachment.url,
+            target: "_blank",
+            title: t("shared.target_blank")
+  end
+end

--- a/app/models/custom/document.rb
+++ b/app/models/custom/document.rb
@@ -1,0 +1,18 @@
+require_dependency Rails.root.join("app", "models", "document").to_s
+
+class Document
+  after_update :fix_attachment_path, if: :saved_change_to_title?
+
+  # NOTE: Fix filename broken when document title changed
+  def fix_attachment_path
+    return if File.exist?(attachment.path)
+
+    folder = File.dirname(attachment.path)
+    return unless Dir.exist?(folder)
+
+    file_path = Dir[folder + '/*'].sort_by {|f| File.stat(f).mtime }.last
+    return unless file_path && File.exist?(file_path)
+
+    File.rename(file_path, attachment.path)
+  end
+end

--- a/app/views/custom/documents/_additional_document.html.erb
+++ b/app/views/custom/documents/_additional_document.html.erb
@@ -1,0 +1,3 @@
+<p><span class="icon-document"></span>&nbsp;
+<%= fixed_document_item_link(document) %>
+</p>

--- a/spec/models/custom/document_spec.rb
+++ b/spec/models/custom/document_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe Document do
+  it_behaves_like "document validations", "budget_investment_document"
+  it_behaves_like "document validations", "proposal_document"
+
+  context "scopes" do
+    describe "#admin" do
+      it "returns admin documents" do
+        admin_document = create(:document, :admin)
+
+        expect(Document.admin).to eq [admin_document]
+      end
+
+      it "does not return user documents" do
+        create(:document, admin: false)
+
+        expect(Document.admin).to be_empty
+      end
+    end
+  end
+
+  context '#fix_attachment_path' do
+    describe 'with new' do
+      let!(:document) { build :document, :budget_investment_document }
+
+      it 'is accessible' do
+        expect(document).to_not receive(:fix_attachment_path)
+        document.save
+        expect(File.exist?(document.reload.attachment.path)).to eq(true)
+      end
+    end
+
+    describe 'with persisted' do
+      let!(:document) { create :document, :budget_investment_document }
+
+      context 'when changing title' do
+        it 'is accessible' do
+          expect(document).to receive(:fix_attachment_path).and_call_original
+          document.update(title: 'New title')
+          expect(File.exist?(document.reload.attachment.path)).to eq(true)
+        end
+      end
+
+      context 'when file not broken' do
+        it 'is not fixed' do
+          expect(File).to receive(:exist?).once.and_return(true)
+          expect(File).to_not receive(:rename)
+          document.update(title: 'New title')
+        end
+      end
+
+      context 'when correct file not in folder' do
+        it 'is not renamed' do
+          expect(File).to receive(:exist?).twice.and_return(false)
+          expect(File).to_not receive(:rename)
+          document.update(title: 'New title')
+        end
+      end
+
+      context 'when changing another attribute' do
+        it 'is accessible' do
+          expect(document).to_not receive(:fix_attachment_path)
+          document.update(admin: !document.admin)
+          expect(File.exist?(document.reload.attachment.path)).to eq(true)
+        end
+      end
+    end
+
+    describe 'with removed' do
+      let!(:document) { create :document, :budget_investment_document }
+      let!(:path) { document.attachment.path }
+
+      it 'is not accessible' do
+        expect(document).to_not receive(:fix_attachment_path)
+        document.destroy
+        expect(File.exist?(path)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Temporary fix waiting for v1.5.0

Repairs document file name when title is changed or when url targets to a non existing file.

References SIS-283568