### PR TITLE
Mejoras en la usabilidad - Elaboración normativa

### DIFF
--- a/app/controllers/admin/legislation/proposals_controller.rb
+++ b/app/controllers/admin/legislation/proposals_controller.rb
@@ -12,4 +12,11 @@ class Admin::Legislation::ProposalsController < Admin::Legislation::BaseControll
     @proposal.toggle :selected
     @proposal.save!
   end
+
+  def summary
+    @proposals = @process.proposals.selected
+    respond_to do |format|
+      format.xlsx { render xlsx: "summary", filename: "proposals-summary-#{Date.current}.xlsx" }
+    end
+  end
 end

--- a/app/controllers/moderation/legislation/proposals_controller.rb
+++ b/app/controllers/moderation/legislation/proposals_controller.rb
@@ -13,6 +13,10 @@ class Moderation::Legislation::ProposalsController < Moderation::BaseController
 
   private
 
+    def resource_name
+      "legislation_proposal"
+    end
+
     def resource_model
       Legislation::Proposal
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,9 +10,11 @@ class UsersController < ApplicationController
   private
 
     def check_slug
-      slug = params[:id].split("-", 2)[1]
+      if params[:id]
+          slug = params[:id].split("-", 2)[1]
 
-      raise ActiveRecord::RecordNotFound unless @user.slug == slug.to_s
+          raise ActiveRecord::RecordNotFound unless @user.slug == slug.to_s
+      end
     end
 
     def valid_interests_access?(user)

--- a/app/helpers/legislation_helper.rb
+++ b/app/helpers/legislation_helper.rb
@@ -4,7 +4,7 @@ module LegislationHelper
   end
 
   def new_legislation_proposal_link_text(process)
-    t("proposals.index.start_proposal")
+    t("legislation.proposals.index.start_proposal")
   end
   # Custom
   def legislation_process_tabs(process)

--- a/app/views/admin/legislation/proposals/_proposals.html.erb
+++ b/app/views/admin/legislation/proposals/_proposals.html.erb
@@ -1,5 +1,14 @@
 <% if proposals.any? %>
-  <h3><%= page_entries_info proposals %></h3>
+  <div>
+    <div class="small-12 medium-8 column clear end">
+      <h3><%= page_entries_info proposals %></h3>
+      </div>
+    <div class="small-12 medium-3 column clear end">
+      <%= link_to t("legislation.summary.download"),
+                  summary_admin_legislation_process_proposals_path(@process, format: :xlsx),
+                  class: "button download-button" %>
+    </div>
+  </div>
 
   <%= render "shared/order_links", i18n_namespace: "admin.legislation.processes.proposals" %>
 
@@ -24,6 +33,7 @@
       <% end %>
     </tbody>
   </table>
+
 
   <%= paginate proposals %>
 <% end %>

--- a/app/views/custom/admin/legislation/proposals/summary.xlsx.axlsx
+++ b/app/views/custom/admin/legislation/proposals/summary.xlsx.axlsx
@@ -1,0 +1,39 @@
+xlsx_package.workbook.add_worksheet(name: "Summary") do |sheet|
+  styles = xlsx_package.workbook.styles
+  title = styles.add_style(b: true)
+  link = styles.add_style(fg_color: "0000FF", u: true)
+
+  sheet.add_row(
+      [
+        t("legislation.processes.process.title")
+      ],
+      style: title
+    )
+  sheet.add_row [@process.title]
+  sheet.add_hyperlink(
+    location: legislation_process_url(@process),
+    ref: sheet.rows.last.cells.first
+  )
+  sheet.rows.last.cells.first.style = link
+
+  sheet.add_row ["", ""]
+
+  if @process.proposals_phase.enabled? && @proposals.any?
+    sheet.add_row(
+      [
+        t("legislation.summary.proposals_phase"),
+        t("legislation.summary.proposals", count: @proposals.count)
+      ],
+      style: title
+    )
+    @proposals.sort_by_supports.each do |proposal|
+      sheet.add_row [proposal.title, t("legislation.summary.votes", count: proposal.votes_score)]
+      sheet.add_hyperlink(
+        location: legislation_process_proposal_url(proposal.legislation_process_id, proposal),
+        ref: sheet.rows.last.cells.first
+      )
+      sheet.rows.last.cells.first.style = link
+    end
+    sheet.add_row ["", ""]
+  end
+end

--- a/app/views/custom/legislation/processes/summary.xlsx.axlsx
+++ b/app/views/custom/legislation/processes/summary.xlsx.axlsx
@@ -3,6 +3,17 @@ xlsx_package.workbook.add_worksheet(name: "Summary") do |sheet|
   title = styles.add_style(b: true)
   link = styles.add_style(fg_color: "0000FF", u: true)
 
+  sheet.add_row(
+      [t("legislation.processes.process.title")],
+      style: title
+    )
+  sheet.add_row [@process.title]
+  sheet.add_hyperlink(
+    location: legislation_process_url(@process),
+    ref: sheet.rows.last.cells.first
+  )
+  sheet.rows.last.cells.first.style = link
+
   if @process.debate_phase.enabled? && @process.questions.any?
     sheet.add_row [t("legislation.summary.debate_phase"), t("legislation.summary.debates", count: @process.questions.count)], style: title
     @process.questions.each do |question|

--- a/app/views/moderation/_menu.html.erb
+++ b/app/views/moderation/_menu.html.erb
@@ -18,6 +18,14 @@
   ),
   (
     [
+      t("moderation.menu.legislation_proposals"),
+      moderation_legislation_proposals_path,
+      controller_name == "legislation_proposals",
+      class: "proposals-link"
+    ] if feature?(:legislation)
+  ),
+  (
+    [
       t("moderation.menu.flagged_debates"),
       moderation_debates_path,
       controller_name == "debates",

--- a/config/locales/custom/en/legislation.yml
+++ b/config/locales/custom/en/legislation.yml
@@ -1,0 +1,135 @@
+en:
+  legislation:
+    annotations:
+      comments:
+        see_all: See all
+        see_complete: See complete
+        replies_count:
+          one: "%{count} reply"
+          other: "%{count} replies"
+        cancel: Cancel
+        publish_comment: Publish Comment
+      form:
+        phase_not_open: This phase is not open
+      index:
+        title: Comments
+        comments_about: Comments about
+        see_in_context: See in context
+      show:
+        title: Comment
+      version_chooser:
+        seeing_version: Commments for version
+        see_text: See text draft
+    draft_versions:
+      changes:
+        title: Changes
+        seeing_changelog_version: Revision changes summary
+        see_text: See text draft
+      show:
+        loading_comments: Loading comments
+        seeing_version: You're seeing draft version
+        select_draft_version: Select draft
+        select_version_submit: see
+        updated_at: updated at %{date}
+        see_changes: see changes summary
+        see_comments: See all comments
+        text_toc: Table of contents
+        text_body: Text
+        text_comments: Comments
+    processes:
+      header:
+        additional_info: Additional information
+        description: Description
+        more_info: More information and context
+      proposals:
+        empty_proposals: There are no proposals
+        filters:
+          random: Random
+          winners: Selected
+      debate:
+        empty_questions: There aren't any questions
+      index:
+        filter: Filter
+        filters:
+          open: Open processes
+          past: Past
+        no_open_processes: There aren't open processes
+        no_past_processes: There aren't past processes
+        section_header:
+          icon_alt: Collaborative legislation icon
+          title: Collaborative legislation
+          help: Help with collaborative legislation
+        section_footer:
+          title: Help with collaborative legislation
+          description: Participate in the debates and processes prior to the approval of new regulations or strategies. Your opinion will be considered.
+      phase_not_open:
+        not_open: This phase is not open yet
+      phase_empty:
+        empty: Nothing published yet
+      process:
+        title: Process
+        see_latest_comments: See latest comments
+        see_latest_comments_title: Comment on this process
+      shared:
+        key_dates: Participation phases
+        homepage: Homepage
+        debate_dates: Debate
+        draft_publication_date: Draft publication
+        allegations_dates: Comments
+        result_publication_date: Final result publication
+        milestones_date: Following
+        proposals_dates: Proposals
+    questions:
+      comments:
+        comment_button: Publish answer
+        comments_title: Open answers
+        comments_closed: Closed phase
+        form:
+          leave_comment: Leave your answer
+      question:
+        debate: Debate
+      show:
+        answer_question: Submit answer
+        next_question: Next question
+        first_question: First question
+        share: Share
+        title: Collaborative legislation process
+      participation:
+        phase_not_open: This phase is not open
+        organizations: Organisations are not permitted to participate in the debate
+        unauthenticated: You must %{signin} or %{signup} to participate.
+        verified_only: Only verified users can participate, %{verify_account}.
+        debate_phase_not_open: Debate phase has finished and answers are not accepted anymore
+    shared:
+      share: Share
+      share_comment: Comment on %{version_name} from process draft %{process_name}
+    proposals:
+      form:
+        tags_label: "Categories"
+      not_verified: "For vote proposals %{verify_account}."
+      process_title: Collaborative legislation process
+    summary:
+      title: "Summary"
+      votes:
+        zero: "%{count} votes"
+        one: "%{count} vote"
+        other: "%{count} votes"
+      debate_phase: "Debate phase"
+      proposals_phase: "Proposals phase"
+      allegations_phase: "Comments phase"
+      debates:
+        zero: "No debates"
+        one: "%{count} debate"
+        other: "%{count} debates"
+      proposals:
+        zero: "No proposals"
+        one: "%{count} proposal"
+        other: "%{count} proposals"
+      download: "Download summary"
+      top_comments:
+        zero: "No comments"
+        one: "%{count} comment"
+        other: "Top comments"
+      most_voted_comments: "Most voted comments"
+      no_allegation: "There are no comments"
+      process_empty: "This process didn't have any participation phases"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -587,13 +587,13 @@ es:
           banner_title: Colores del encabezado
         index:
           create: Nuevo proceso
-          title: Procesos de legislación colaborativa
+          title: Procesos de elaboración normativa
           filters:
             active: Activos
             all: Todos
         new:
           back: Volver
-          title: Crear nuevo proceso de legislación colaborativa
+          title: Crear nuevo proceso de elaboración normativa
           submit_button: Crear proceso
         proposals:
           orders:
@@ -789,7 +789,7 @@ es:
       title_settings: Configuración
       title_site_customization: Contenido del sitio
       title_booths: Urnas de votación
-      legislation: Legislación colaborativa
+      legislation: Elaboración normativa
       users: Usuarios
       dashboard: Panel de progreso de propuestas
       administrator_tasks: Recursos solicitados

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -254,7 +254,7 @@ es:
       administration_menu: Menú
       administration: Administración
       available_locales: Idiomas disponibles
-      collaborative_legislation: Legislación colaborativa
+      collaborative_legislation: Elaboración normativa
       debates: Debates
       locale: "Idioma:"
       logo: Logo de CONSUL
@@ -915,7 +915,7 @@ es:
         title: Votar
         description: Ahora tu voto es importante para la toma de decisión de las políticas públicas. Vota las opciones que consideres más relevantes
       normativa:
-        title: Legislación colaborativa
+        title: Elaboración normativa
         description: Participa de manera activa en la elaboración de legislación, planes y programas.
       presupuesto:
         title: Presupuestos participativos

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -68,11 +68,11 @@ es:
         no_public_phase_processes: No hay procesos
         no_relevance_processes: No hay procesos
         section_header:
-          icon_alt: Icono de Legislación colaborativa
-          title: Legislación colaborativa
-          help: Ayuda sobre Legislación colaborativa
+          icon_alt: Icono de Elaboración normativa
+          title: Elaboración normativa
+          help: Ayuda sobre Elaboración normativa
         section_footer:
-          title: Ayuda sobre Legislación colaborativa
+          title: Ayuda sobre Elaboración normativa
           description: Participa en los debates y procesos previos a la aprobación de nuevas normas o planes. Tu opinión será tenida en cuenta.
       phase_not_open:
         not_open: Esta fase del proceso todavía no está abierta
@@ -108,7 +108,7 @@ es:
         next_question: Siguiente pregunta
         first_question: Primera pregunta
         share: Compartir
-        title: Proceso de Legislación colaborativa
+        title: Proceso de Elaboración normativa
       participation:
         phase_not_open: Esta fase no está abierta
         organizations: Las organizaciones no pueden participar en el debate
@@ -122,7 +122,7 @@ es:
       form:
         tags_label: "Categorías"
       not_verified: "Para votar propuestas %{verify_account}."
-      process_title: Proceso de Legislación colaborativa
+      process_title: Proceso de Elaboración normativa
     summary:
       title: "Resumen"
       votes:

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -79,6 +79,7 @@ es:
       phase_empty:
         empty: No hay nada publicado todavía
       process:
+        title: Proceso
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
@@ -123,6 +124,8 @@ es:
         tags_label: "Categorías"
       not_verified: "Para votar propuestas %{verify_account}."
       process_title: Proceso de Elaboración normativa
+      index:
+        start_proposal: Crear una propuesta
     summary:
       title: "Resumen"
       votes:

--- a/config/locales/custom/es/legislators.yml
+++ b/config/locales/custom/es/legislators.yml
@@ -9,7 +9,7 @@ es:
       legislators: Legisladores
     legislators:
       header:
-        title: Legislación colaborativa
+        title: Elaboración normativa
       index:
         title: Legisladores
         name: Nombre

--- a/config/locales/custom/es/moderation.yml
+++ b/config/locales/custom/es/moderation.yml
@@ -1,0 +1,112 @@
+es:
+  moderation:
+    actions:
+      confirm_action: "¿Estás seguro? %{action}"
+    comments:
+      index:
+        block_authors: Bloquear autores
+        filter: Filtro
+        filters:
+          all: Todos
+          pending_flag_review: Pendientes
+          with_ignored_flag: Marcados como revisados
+        headers:
+          comment: Comentario
+          moderate: Moderar
+        hide: Ocultar comentarios
+        ignore_flags: Marcar como revisados
+        orders:
+          flags: Más denunciados
+          newest: Más nuevos
+        title: Comentarios
+    dashboard:
+      index:
+        title: Moderar
+    debates:
+      index:
+        block_authors: Bloquear autores
+        filter: Filtrar
+        filters:
+          all: Todos
+          pending_flag_review: Pendientes
+          with_ignored_flag: Marcados como revisados
+        headers:
+          debate: Debate
+          moderate: Moderar
+        hide: Ocultar debates
+        ignore_flags: Marcar como revisados
+        orders:
+          created_at: Más nuevos
+          flags: Más denunciados
+        title: Debates
+    header:
+      title: Moderación
+    menu:
+      flagged_comments: Comentarios
+      flagged_debates: Debates
+      flagged_investments: Proyectos de gasto
+      proposals: Propuestas
+      proposal_notifications: Notificaciones de propuestas
+      legislation_proposals: Propuestas legislativas
+      users: Bloquear usuarios
+    proposals:
+      index:
+        block_authors: Bloquear autores
+        filter: Filtro
+        filters:
+          all: Todas
+          pending_flag_review: Pendientes de revisión
+          with_ignored_flag: Marcadas como revisadas
+        headers:
+          moderate: Moderar
+          proposal: Propuesta
+        hide: Ocultar Propuestas
+        ignore_flags: Marcar como revisadas
+        orders:
+          created_at: Más recientes
+          flags: Más denunciadas
+        title: Propuestas
+    budget_investments:
+      index:
+        block_authors: Bloquear autores
+        filter: Filtro
+        filters:
+          all: Todos
+          pending_flag_review: Pendientes de revisión
+          with_ignored_flag: Marcados como revisados
+        headers:
+          moderate: Moderar
+          budget_investment: Proyecto de gasto
+        hide: Ocultar proyectos de gasto
+        ignore_flags: Marcar como revisados
+        orders:
+          created_at: Más recientes
+          flags: Más denunciadas
+        title: Proyectos de gasto
+    proposal_notifications:
+      index:
+        block_authors: Bloquear autores
+        filter: Filtro
+        filters:
+          all: Todas
+          pending_review: Pendientes de revisión
+          ignored: Marcadas como revisadas
+        headers:
+          moderate: Moderar
+          proposal_notification: Notificación de propuesta
+        hide: Ocultar notificaciones
+        ignore_flags: Marcar como revisadas
+        orders:
+          created_at: Más recientes
+          moderated: Moderadas
+        title: Notificaciones de propuestas
+    users:
+      index:
+        block: Bloquear
+        confirm_block: "¿Seguro? Esto ocultará a \"%{name}\" así como todos sus contenidos."
+        confirm_hide: "¿Seguro? Esto ocultará a \"%{name}\" sin ocultar sus contenidos."
+        hide: Ocultar
+        search_placeholder: email o nombre de usuario
+        title: Bloquear usuarios
+      notice_block: Usuario bloqueado. Se han ocultado todos sus contenidos y comentarios.
+      notice_hide: Usuario ocultado. Todos sus contenidos y comentarios siguen disponibles.

--- a/config/locales/custom/es/pages.yml
+++ b/config/locales/custom/es/pages.yml
@@ -16,7 +16,7 @@ es:
         budgets: "Presupuestos participativos"
         polls: "Votaciones"
         other: "Otra información de interés"
-        processes: "Legislación colaborativa"
+        processes: "Elaboración normativa"
       debates:
         title: "Debates"
         description: "En la sección de %{link} puedes compartir tu opinión con otras personas sobre temas que te preocupen relacionados con la Comunitat Valenciana. Es un lugar para generar conocimiento e inteligencia colectiva que conduzcan a acciones concretas por parte del Consell. <br/> <br/>Puedes abrir debates, comentarlos y valorarlos con los botones de <strong>Estoy de acuerdo</strong> o <strong>No estoy de acuerdo</strong>.
@@ -63,13 +63,13 @@ es:
         feature_1: "Para participar en las votaciones tienes que %{link} y verificar tu cuenta."
         feature_1_link: "registrarte en %{org_name}"
       processes:
-        title: "Legislación colaborativa"
+        title: "Elaboración normativa"
         description: "En la sección de %{link} puedes colaborar en la redacción y modificación de normativa, planes y programas de la Generalitat Valenciana. Las aportaciones de la ciudadanía serán analizadas y tenidas en cuenta en la redacción definitiva de las normas o en la planificación de las actuaciones. <br/> <br/>
       <strong>¿Cómo funciona?</strong><br/><br/>
       Cuando accedas a este área podrás ver los procesos “activos” y los “terminados”. Si seleccionas uno de los procesos podrás acceder a información acerca de la norma o el plan que se está elaborando y revisar las aportaciones que se han hecho al documento.<br/><br/>
       También puedes hacer tus propias aportaciones, siempre y cuando te hayas registrado. En primer lugar puedes acceder al área de “debate previo”, donde encontrarás preguntas a las que podrás responder y sobre las que podrás debatir. En el apartado de “propuestas” podrás ver las que otras personas han hecho o realizar las tuyas propias. Y, por último, en “comentarios” podrás comentar los documentos, seleccionando el texto que quieres comentar."
-        link: "legislación colaborativa"
-        feature: "Para participar en la legislación colaborativa tienes que %{link} y verificar tu cuenta."
+        link: "elaboración normativa"
+        feature: "Para participar en la elaboración normativa tienes que %{link} y verificar tu cuenta."
         feature_link: "registrarte en %{org_name}"
       faq:
         title: "¿Problemas técnicos?"
@@ -129,7 +129,7 @@ es:
               page_column: Presupuestos participativos
             -
               key_column: 5
-              page_column: Legislación colaborativa
+              page_column: Elaboración normativa
         browser_table:
           description: "Dependiendo del sistema operativo y del navegador que se utilice, la combinación de teclas será la siguiente:"
           caption: Combinación de teclas dependiendo del sistema operativo y navegador

--- a/config/locales/custom/es/settings.yml
+++ b/config/locales/custom/es/settings.yml
@@ -188,7 +188,7 @@ es:
       polls_description: "Las votaciones ciudadanas son un mecanismo de participación por el que la ciudadanía con derecho a voto puede tomar decisiones de forma directa"
       budgets: "Presupuestos participativos"
       budgets_description: "Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto"
-      legislation: "Legislación colaborativa"
+      legislation: "Elaboración normativa"
       legislation_description: "En los procesos participativos se ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la sociedad y de dar su opinión sobre ciertas actuaciones que se tiene previsto llevar a cabo"
     html:
       per_page_code_head: "Código a incluir en cada página (<head>)"
@@ -227,5 +227,5 @@ es:
         polls_description: Permitir alineamiento de los Objetivos de Desarrollo Sostenible en votaciones
         budgets: Alineamiento ODS en presupuestos participativos
         budgets_description: Permitir alineamiento de los Objetivos de Desarrollo Sostenible en presupuestos participativos
-        legislation: Alineamiento ODS en legislación colaborativa
-        legislation_description: Permitir alineamiento de los Objetivos de Desarrollo Sostenible en legislación colaborativa
+        legislation: Alineamiento ODS en elaboración normativa
+        legislation_description: Permitir alineamiento de los Objetivos de Desarrollo Sostenible en elaboración normativa

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -357,13 +357,13 @@ val:
         index:
           create: Nou procés
           delete: Eliminar
-          title: Processos de legislació col·laborativa
+          title: Processos de elaboració normativa
           filters:
             active: Actius
             all: Tots
         new:
           back: Tornar
-          title: Crear procés de legislació col·laborativa
+          title: Crear procés de elaboració normativa
           submit_button: Crear procés
         proposals:
           select_order: Ordenar per
@@ -553,7 +553,7 @@ val:
       title_settings: Configuració
       title_site_customization: Personalitzar lloc
       title_booths: Cabines de vot
-      legislation: Legislació col·laborativa
+      legislation: Elaboració normativa
       users: Usuaris
     administrators:
       index:
@@ -1027,7 +1027,7 @@ val:
           organizations: "Nom, email o telèfon"
           poll_officers: "Cercar presidents de taula"
           poll_questions: "Cercar preguntes"
-          processes: "Cercar processos de legislació col·laborativa pero títol o descripció"
+          processes: "Cercar processos de elaboració normativa pero títol o descripció"
           proposals: "Cercar propostes per títol, codi, descripció o pregunta"
           users: "Cercar usuari per nom o correu electrònic"
         search: "Cercar"

--- a/config/locales/custom/val/general.yml
+++ b/config/locales/custom/val/general.yml
@@ -211,8 +211,8 @@ val:
       administration_menu: Menú
       administration: Administració
       available_locales: Idiomes disponibles
-      legislation: Legislació col·laborativa
-      collaborative_legislation: Legislació col·laborativa
+      legislation: Elaboració normativa
+      collaborative_legislation: Elaboració normativa
       debates: Debats
       locale: "Idioma:"
       logo: Logo de CONSUL
@@ -690,7 +690,7 @@ val:
         title: Votar
         description: Ara el teu vot és important per a la presa de decisió de les polítiques públiques. Vota les opcions que consideres més rellevants.
       normativa:
-        title: Legislació col·laborativa
+        title: Elaboració normativa
         description: Participa de manera activa en l’elaboració de legislació, plans i programes.
       presupuesto:
         title: Pressupostos participatius

--- a/config/locales/custom/val/legislation.yml
+++ b/config/locales/custom/val/legislation.yml
@@ -79,6 +79,7 @@ val:
       phase_empty:
         empty: No hi ha res publicat encara
       process:
+        title: Proces
         see_latest_comments: Vore les últimes aportacions
         see_latest_comments_title: Aportar a aquest procés
       shared:

--- a/config/locales/custom/val/legislation.yml
+++ b/config/locales/custom/val/legislation.yml
@@ -68,11 +68,11 @@ val:
         no_public_phase_processes: No hi ha processos
         no_relevance_processes: No hi ha processos
         section_header:
-          icon_alt: Icona de Legislació col·laborativa
-          title: Legislació col·laborativa
-          help: Ajuda sobre legislació col·laborativa
+          icon_alt: Icona de Elaboració normativa
+          title: Elaboració normativa
+          help: Ajuda sobre elaboració normativa
         section_footer:
-          title: Ajuda sobre legislació col·laborativa
+          title: Ajuda sobre elaboració normativa
           description: Participa en els debats y processos previs a la aprovació d'una norma o d'una actuació municipal. La teua opinió serà tinguda en compte per l'Ajuntament.
       phase_not_open:
         not_open: Esta fase del procés encara no esta oberta
@@ -108,7 +108,7 @@ val:
         next_question: Següent pregunta
         first_question: Primera pregunta
         share: Compartir
-        title: Proces de legislació col·laborativa
+        title: Proces de elaboració normativa
       participation:
         phase_not_open: Esta fase del procés no esta oberta
         organizations: Les organitzacions no poden participar en el debat

--- a/config/locales/custom/val/legislators.yml
+++ b/config/locales/custom/val/legislators.yml
@@ -9,7 +9,7 @@ es:
       legislators: Legisladores
     legislators:
       header:
-        title: Legislación colaborativa
+        title: Elaboración normativa
       index:
         title: Legisladores
         name: Nombre

--- a/config/locales/custom/val/moderation.yml
+++ b/config/locales/custom/val/moderation.yml
@@ -1,0 +1,106 @@
+val:
+  moderation:
+    comments:
+      index:
+        block_authors: Bloquejar autors
+        filter: Filtre
+        filters:
+          all: Totes
+          pending_flag_review: Pendents
+          with_ignored_flag: Marcats com revisats
+        headers:
+          comment: Comentari
+          moderate: Moderar
+        hide: Ocultar comentaris
+        ignore_flags: Marcar com revisats
+        orders:
+          flags: Més denunciats
+          newest: Més nous
+        title: Comentaris
+    dashboard:
+      index:
+        title: Moderació
+    debates:
+      index:
+        block_authors: Bloquejar autors
+        filter: Filtre
+        filters:
+          all: Totes
+          pending_flag_review: Pendents
+          with_ignored_flag: Marcats com revisats
+        headers:
+          debate: Debat
+          moderate: Moderar
+        hide: Ocultar debats
+        ignore_flags: Marcar com revisats
+        orders:
+          created_at: Més nous
+          flags: Més denunciats
+        title: Debats
+    header:
+      title: Moderació
+    menu:
+      flagged_comments: Comentaris
+      flagged_debates: Debats
+      flagged_investments: Projectes de pressupostos participatius
+      proposals: Propostes
+      proposal_notifications: Notificacions de propostes
+      legislation_proposals: Propostes legislatives
+      users: Bloquejar usuaris
+    proposals:
+      index:
+        block_authors: Bloquejar autors
+        filter: Filtre
+        filters:
+          all: Totes
+          pending_flag_review: Pendents de revisió
+          with_ignored_flag: Marcar com revisats
+        headers:
+          moderate: Moderar
+          proposal: Proposta
+        hide: Ocultar propostes
+        ignore_flags: Marcar com revisats
+        orders:
+          created_at: Més recents
+          flags: Més denunciats
+        title: Propostes
+    budget_investments:
+      index:
+        block_authors: Bloquejar autors
+        filter: Filtre
+        filters:
+          all: Totes
+          pending_flag_review: Pendents
+          with_ignored_flag: Marcats com revisats
+        headers:
+          moderate: Moderar
+          budget_investment: Pressupost participatiu
+        hide: Ocultar propostes d'inversió
+        ignore_flags: Marcar com revisats
+        orders:
+          created_at: Más recents
+          flags: Més denunciats
+        title: Projectes de pressupostos participatius
+    proposal_notifications:
+      index:
+        block_authors: Bloquejar autors
+        filter: Filtre
+        filters:
+          all: Totes
+          pending_review: Pendents de revisió
+          ignored: Marcar com revisats
+        headers:
+          moderate: Moderar
+          proposal_notification: Notificació de proposta
+        hide: Ocultar propostes
+        ignore_flags: Marcar com revisats
+        orders:
+          created_at: Más recents
+          moderated: Moderades
+        title: Notificacions de propostes
+    users:
+      index:
+        hide: Bloquejar
+        search_placeholder: email o nom d'usuari
+        title: Bloquejar usuaris
+      notice_hide: Usuari bloquejat. S'han ocultat tots els seus debats i comentaris.

--- a/config/locales/custom/val/pages.yml
+++ b/config/locales/custom/val/pages.yml
@@ -13,7 +13,7 @@ val:
         budgets: "Pressupostos participatius"
         polls: "Votacions"
         other: "Altra informació d'interés"
-        processes: "Legislació col·laborativa"
+        processes: "Elaboració normativa"
       debates:
         title: "Debats"
         description: "En la secció de %{link} pots compartir la teua opinió amb altres persones sobre temes que et preocupen relacionats amb la Comunitat Valenciana. És un lloc per a generar coneixement i intel·ligència col·lectiva que conduïsquen a accions concretes per part del Consell.<br/><br/>
@@ -59,13 +59,13 @@ Has de tindre en compte que obtindre els suports necessaris no garanteix que la 
         feature_1: "Per a participar en les votacions has de %{link} i verificar el teu compte."
         feature_1_link: "registrar-te en %{org_name}"
       processes:
-        title: "Legislació col·laborativa"
+        title: "Elaboració normativa"
         description: "En la secció d'%{link} pots col·laborar en la redacció i modificació de normativa, plans i programes de la Generalitat Valenciana. Les aportacions de la ciutadania seran analitzades i tingudes en compte en la redacció definitiva de les normes o en la planificació de les actuacions.<br/><br/>
         <strong>Com funciona?</strong><br/><br/>
         Quan accedisques a aquesta àrea podràs veure els processos “actius” i els “acabats”. Si selecciones un dels processos, podràs accedir a informació sobre la norma o el pla que s’està elaborant i revisar les aportacions que s’han fet al document.<br/><br/>
         També pots fer les teues aportacions, sempre que t'hages registrat. En primer lloc, pots accedir a l’àrea de “debat previ”, on trobaràs preguntes a les quals podràs respondre i sobre les quals podràs debatre. En l’apartat de “propostes” podràs veure les que altres persones han fet o realitzar les teues pròpies. I, finalment, en “comentaris” podràs comentar els documents, seleccionant el text que vols comentar."
-        link: "legislació col·laborativa"
-        feature: "Per a participar en la legislació col·laborativa has de registrar-te en %{link} i verificar el teu compte."
+        link: "Elaboració normativa"
+        feature: "Per a participar en la elaboració normativa has de registrar-te en %{link} i verificar el teu compte."
         feature_link: "registrar-te en %{org_name}"
       faq:
         title: "Problemes tècnics?"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -235,6 +235,7 @@ namespace :admin do
       resources :questions
       resources :proposals do
         member { patch :toggle_selection }
+        get :summary, on: :collection# Custom
       end
       resources :draft_versions
       resources :milestones

--- a/spec/controllers/custom/admin/legislation/proposals_controller_spec.rb
+++ b/spec/controllers/custom/admin/legislation/proposals_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Admin::Legislation::ProposalsController do
+  let(:legislation_process) { create(:legislation_process, end_date: Date.current - 1.day) }
+
+  it "download excel file test" do
+    create(:legislation_question, process: legislation_process, title: "Question 1")
+
+    get :summary, params: { id: legislation_process, format: :xlsx }
+
+    expect(response).to be_successful
+  end
+end


### PR DESCRIPTION
## References
> Issue/6811

## Objectives
> Mejorar elaboración normativa

## Visual Changes

- Cambiar el nombre de la sección "Legislación colaborativa" por Elaboración normativa / elaboración normativa

- Comprobar botón de crear iniciativa en legislación crea propuesta y no iniciativas

- Cambiar el nombre del botón por "Crear Propuestas"

- Habilitar el botón de descargar propuestas para que los legisladores puedan ir descargando las propuestas para crear el informe de resultados aunque no esté habilitada la pestaña "Resumen".

