### PR TITLE
Mejoras en la usabilidad - Debates e iniciativas

### DIFF
--- a/app/assets/stylesheets/custom/debates/geozones.scss
+++ b/app/assets/stylesheets/custom/debates/geozones.scss
@@ -1,0 +1,5 @@
+.debates-geozones {
+  a {
+    @include focus-outline-on-img;
+  }
+}

--- a/app/components/custom/debates/form_component.html.erb
+++ b/app/components/custom/debates/form_component.html.erb
@@ -1,0 +1,57 @@
+<%= translatable_form_for(debate, html: { class: "debate-form" }) do |f| %>
+  <%= render "shared/errors", resource: debate %>
+
+  <fieldset class="required-fields">
+    <legend><%= t("shared.required") %></legend>
+
+    <%= render "shared/globalize_locales", resource: debate %>
+
+    <%= f.translatable_fields do |translations_form| %>
+      <div>
+        <%= translations_form.text_field :title,
+                                         maxlength: Debate.title_max_length,
+                                         data: suggest_data(debate) %>
+      </div>
+      <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
+
+      <div>
+        <%= translations_form.text_area :description,
+                                        maxlength: Debate.description_max_length,
+                                        class: "html-area" %>
+      </div>
+    <% end %>
+  </fieldset>
+
+  <%= f.invisible_captcha :subtitle %>
+
+  <fieldset>
+    <legend><%= t("shared.optional") %></legend>
+
+    <% if Geozone.any? %>
+      <div>
+        <%= f.select :geozone_id, geozone_select_options,
+                     include_blank: t("geozones.none") %>
+      </div>
+    <% end %>
+
+    <div>
+      <%= f.text_field :tag_list, value: debate.tag_list.to_s,
+                                  hint: t("debates.form.tags_instructions"),
+                                  placeholder: t("debates.form.tags_placeholder"),
+                                  data: { js_url: suggest_tags_path },
+                                  class: "tag-autocomplete" %>
+    </div>
+
+    <%= render SDG::RelatedListSelectorComponent.new(f) %>
+  </fieldset>
+
+  <div class="actions">
+    <% if debate.new_record? %>
+      <div>
+        <%= render Shared::AgreeWithTermsOfServiceFieldComponent.new(f) %>
+      </div>
+    <% end %>
+
+    <%= f.submit(class: "button", value: t("debates.#{action_name}.form.submit_button")) %>
+  </div>
+<% end %>

--- a/app/components/custom/debates/form_component.rb
+++ b/app/components/custom/debates/form_component.rb
@@ -1,0 +1,7 @@
+class Debates::FormComponent < ApplicationComponent; end
+
+require_dependency Rails.root.join("app", "components", "debates", "form_component").to_s
+
+class Debates::FormComponent
+  use_helpers :suggest_data, :geozone_select_options
+end

--- a/app/components/custom/debates/geozones_component.html.erb
+++ b/app/components/custom/debates/geozones_component.html.erb
@@ -1,0 +1,9 @@
+<div class="sidebar-divider"></div>
+
+<div class="debatess-geozones">
+  <h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
+  <br>
+  <%= link_to map_debates_path, id: "map", title: t("shared.tags_cloud.districts_list") do %>
+    <%= image_tag(image_path_for("map.jpg"), alt: t("shared.tags_cloud.districts_list")) %>
+  <% end %>
+</div>

--- a/app/components/custom/debates/geozones_component.rb
+++ b/app/components/custom/debates/geozones_component.rb
@@ -1,0 +1,7 @@
+class Debates::GeozonesComponent < ApplicationComponent
+  use_helpers :image_path_for
+
+  def render?
+    Geozone.any?
+  end
+end

--- a/app/components/custom/shared/advanced_search_component.html.erb
+++ b/app/components/custom/shared/advanced_search_component.html.erb
@@ -11,7 +11,7 @@
       <%= text_field_tag "search", params[:search],
                           placeholder: t("shared.advanced_search.general_placeholder") %>
     </div>
-    <% if debates? %>
+    <% if proposals? %>
       <div class="filter">
         <label for="advanced_search_tag"><%= t("shared.advanced_search.category_type") %>
         </label>
@@ -46,6 +46,14 @@
         </div>
       </div>
     </div>
+
+    <% if proposals? || debates? %>
+      <div class="filter">
+        <label for="advanced_search_geozone"><%= t("shared.advanced_search.geozone") %></label>
+        <%= select_tag("advanced_search[geozone]", geozones_search_options,
+                      include_blank: t("shared.advanced_search.geozone_blank")) %>
+      </div>
+    <% end %>
 
     <% if sdg? %>
       <div class="filter">

--- a/app/components/custom/shared/advanced_search_component.rb
+++ b/app/components/custom/shared/advanced_search_component.rb
@@ -4,11 +4,20 @@ require_dependency Rails.root.join("app", "components", "shared", "advanced_sear
 
 class Shared::AdvancedSearchComponent
   def debates?
+    controller_path == "debates"
+  end
+
+  def proposals?
     controller_path == "proposals"
   end
 
   def categories_search_options
     options_for_select(Tag.category.order(:name).map { |i| [i.name, i.name] },
                        params[:advanced_search].try(:[], :tag))
+  end
+
+  def geozones_search_options
+    options_for_select(Geozone.order(name: :asc).map { |g| [g.name, g.id] },
+                       params[:advanced_search].try(:[], :geozone))
   end
 end

--- a/app/controllers/custom/debates_controller.rb
+++ b/app/controllers/custom/debates_controller.rb
@@ -1,6 +1,13 @@
 require_dependency Rails.root.join("app", "controllers", "debates_controller").to_s
 
 class DebatesController
+  before_action :load_geozones, only: [:edit, :map]
+
+  def map
+    @debate = Debate.new
+    @tag_cloud = tag_cloud
+  end
+
   private
 
     def allowed_params

--- a/app/controllers/custom/debates_controller.rb
+++ b/app/controllers/custom/debates_controller.rb
@@ -1,0 +1,9 @@
+require_dependency Rails.root.join("app", "controllers", "debates_controller").to_s
+
+class DebatesController
+  private
+
+    def allowed_params
+      [:tag_list, :terms_of_service, :geozone_id, :related_sdg_list, translation_params(Debate)]
+    end
+end

--- a/app/models/custom/concerns/filterable.rb
+++ b/app/models/custom/concerns/filterable.rb
@@ -5,6 +5,8 @@ module Filterable
     base.class_eval do
       scope :by_tag, ->(tag) { where(tags: { name: tag }) }
       scope :by_id, ->(id) { where(id: id) }
+      scope :by_geozone, ->(id) { where(geozone_id: id) }
+
     end
   end
 
@@ -12,7 +14,7 @@ module Filterable
     def allowed_filter?(filter, value)
       return if value.blank?
 
-      ["official_level", "date_range", "tag", "id"].include?(filter)
+      ["official_level", "date_range", "tag", "geozone", "id"].include?(filter)
     end
   end
 end

--- a/app/views/custom/debates/index.html.erb
+++ b/app/views/custom/debates/index.html.erb
@@ -81,6 +81,7 @@
         <%= yield :header_addon %><%# Custom %>
         <%= link_to t("debates.index.start_debate"), new_debate_path, class: "button expanded" %>
         <%= render "shared/tag_cloud", taggable: "Debate" %>
+        <%= render Debates::GeozonesComponent.new %>
       </aside>
     </div>
 

--- a/app/views/custom/debates/map.html.erb
+++ b/app/views/custom/debates/map.html.erb
@@ -1,0 +1,50 @@
+<div class="row">
+  <div class="small-12 medium-9 column margin-top">
+
+    <h1><%= t("map.title") %></h1>
+
+    <div class="row">
+      <div class="small-12 medium-3 column">
+        <ul id="geozones" class="no-bullet">
+          <% @geozones.each do |geozone| %>
+            <li><%= link_to geozone.name, debates_path(search: geozone.name) %></li>
+          <% end %>
+        </ul>
+      </div>
+
+      <div class="show-for-medium medium-9 column text-center">
+        <%= image_tag(image_path_for("map.jpg"), usemap: "#map") %>
+      </div>
+
+      <map name="map" id="html_map">
+        <% @geozones.each do |geozone| %>
+          <area shape="poly"
+                coords="<%= geozone.html_map_coordinates %>"
+                href="<%= polymorphic_path(@debate, search: geozone.name) %>"
+                title="<%= geozone.name %>"
+                alt="<%= geozone.name %>">
+        <% end %>
+      </map>
+    </div>
+
+    <h2><%= t("map.debate_for_district") %></h2>
+
+    <%= form_for(@debate, url: new_debate_path, method: :get) do |f| %>
+      <div class="small-12 medium-4">
+        <%= f.select :geozone_id, geozone_select_options, include_blank: t("geozones.none") %>
+      </div>
+
+      <div class="actions small-12">
+        <%= f.submit(class: "button radius", value: t("map.start_debate")) %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="small-12 medium-3 column">
+    <aside class="sidebar">
+      <%= link_to t("map.start_debate"),
+                  new_debate_path, class: "button radius expand" %>
+      <%= render "shared/tag_cloud", taggable: "Debate" %>
+    </aside>
+  </div>
+</div>

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -730,6 +730,8 @@ es:
       target_blank: "Elige una meta"
       title: "Búsqueda avanzada"
       to: "Hasta"
+      geozone: "Ámbito de actuación"
+      geozone_blank: "Elige un ámbito de actuación"
     author_info:
       author_deleted: Usuario eliminado
       email_deleted: Email eliminado

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -302,7 +302,9 @@ es:
   map:
     title: "Provincias"
     proposal_for_district: "Crea una propuesta para tu provincia"
+    debate_for_district: "Crea un debate para tu provincia"
     start_proposal: Crea una propuesta
+    start_debate: Crea un debate
   omniauth:
     facebook:
       sign_in: Entra con Facebook

--- a/config/locales/custom/val/general.yml
+++ b/config/locales/custom/val/general.yml
@@ -257,7 +257,9 @@ val:
   map:
     title: "Províncies"
     proposal_for_district: "Crea una proposta per al teu província"
+    debate_for_district: "Crea un debat per a la teua província"
     start_proposal: Crea una proposta
+    start_debate: Crea un debat
   omniauth:
     facebook:
       sign_in: Entrar amb Facebook

--- a/config/routes/debate.rb
+++ b/config/routes/debate.rb
@@ -7,6 +7,7 @@ resources :debates do
   end
 
   collection do
+    get :map #Custom
     get :suggest
     put "recommendations/disable", only: :index, controller: "debates", action: :disable_recommendations
   end


### PR DESCRIPTION
## References

> Issue/6809

## Objectives

> Mejorar selección y filtro de localización de los debates e iniciativas

## Visual Changes

- Añadir en los formularios de creación un campo extra que sea localización.
- Añadir en el buscador avanzado la opción de filtrar por localización.
- En el menú lateral de debates e iniciativas, permitir filtrar clicando sobre el mapa en la comarca elegida.

