### PR TITLE
Mejoras en la usabilidad - Presupuestos participativos

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -7,3 +7,29 @@
 
 //= require custom/welcome_counter
 //= require custom/select_local
+
+(function() {
+  "use strict";
+
+  App = App || {};
+
+  App.Investments = {
+    initializeSelection: function() {
+      var selectAllButton = document.getElementById('select-all');
+      var checkboxes = document.querySelectorAll('input[type="checkbox"][name="investment_ids[]"]');
+
+      selectAllButton.addEventListener('click', function() {
+        checkboxes.forEach(function(checkbox) {
+          checkbox.checked = true;
+        });
+      });
+    },
+    initialize: function() {
+      this.initializeSelection();
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', function() {
+    App.Investments.initialize();
+  });
+}).call(this);

--- a/app/assets/javascripts/custom/investment_report_alert.js
+++ b/app/assets/javascripts/custom/investment_report_alert.js
@@ -1,0 +1,20 @@
+(function() {
+  "use strict";
+  App.InvestmentReportAlert = {
+    initialize: function() {
+      $("#js-investment-report-alert").on("click", function() {
+        if (this.checked && $("#budget_investment_feasibility_unfeasible").is(":checked")) {
+          return confirm(this.dataset.alert + "\n" + this.dataset.notFeasibleAlert);
+        } else if (this.checked && $("#budget_investment_feasibility_not_selected").is(":checked")) {
+          return confirm(this.dataset.alert + "\n" + this.dataset.notSelectedAlert);
+        } else if ($("#budget_investment_feasibility_takecharge").is(":checked")) {
+           return confirm(this.dataset.alert + "\n" + this.dataset.takechargeAlert);
+        } else if ($("#budget_investment_feasibility_nextyearbudget").is(":checked")) {
+          return confirm(this.dataset.alert + "\n" + this.dataset.nextYearBudgetAlert);
+        } else if (this.checked) {
+          return confirm(this.dataset.alert);
+        }
+      });
+    }
+  };
+}).call(this);

--- a/app/assets/javascripts/custom/valuation_budget_investment_form.js
+++ b/app/assets/javascripts/custom/valuation_budget_investment_form.js
@@ -1,0 +1,72 @@
+(function() {
+  "use strict";
+  App.ValuationBudgetInvestmentForm = {
+    showFeasibleFields: function() {
+      $("#valuation_budget_investment_edit_form #unfeasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #feasible_fields").show();
+      $("#valuation_budget_investment_edit_form #not_selected_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #next_year_budget_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #takecharge_fields").hide("down");
+    },
+    showNotFeasibleFields: function() {
+      $("#valuation_budget_investment_edit_form #feasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #unfeasible_fields").show();
+      $("#valuation_budget_investment_edit_form #not_selected_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #next_year_budget_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #takecharge_fields").hide("down");
+    },
+    showNotSelectedFields: function() {
+      $("#valuation_budget_investment_edit_form #feasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #unfeasible_fields").hide();
+      $("#valuation_budget_investment_edit_form #not_selected_fields").show("down");
+      $("#valuation_budget_investment_edit_form #next_year_budget_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #takecharge_fields").hide("down");
+    },
+    showTakechargeFields: function() {
+      $("#valuation_budget_investment_edit_form #feasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #unfeasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #not_selected_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #takecharge_fields").show("down");
+      $("#valuation_budget_investment_edit_form #next_year_budget_fields").hide("down");
+    },
+    showNextYearBudgetFields: function() {
+      $("#valuation_budget_investment_edit_form #feasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #unfeasible_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #not_selected_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #takecharge_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #next_year_budget_fields").show("down");
+    },
+    showAllFields: function() {
+      $("#valuation_budget_investment_edit_form #feasible_fields").show("down");
+      $("#valuation_budget_investment_edit_form #unfeasible_fields").show("down");
+      $("#valuation_budget_investment_edit_form #not_selected_fields").show("down");
+      $("#valuation_budget_investment_edit_form #next_year_budget_fields").hide("down");
+      $("#valuation_budget_investment_edit_form #takecharge_fields").hide("down");
+    },
+    showFeasibilityFields: function() {
+      var feasibility;
+      feasibility = $("#valuation_budget_investment_edit_form input[type=radio][name='budget_investment[feasibility]']:checked").val();
+      if (feasibility === "feasible") {
+        App.ValuationBudgetInvestmentForm.showFeasibleFields();
+      } else if (feasibility === "unfeasible") {
+        App.ValuationBudgetInvestmentForm.showNotFeasibleFields();
+      } else if (feasibility === "not_selected") {
+        App.ValuationBudgetInvestmentForm.showNotSelectedFields();
+      } else if (feasibility === "takecharge") {
+        App.ValuationBudgetInvestmentForm.showTakechargeFields();
+      } else if (feasibility === "nextyearbudget") {
+        App.ValuationBudgetInvestmentForm.showNextYearBudgetFields();
+      }
+    },
+    showFeasibilityFieldsOnChange: function() {
+      $("#valuation_budget_investment_edit_form input[type=radio][name='budget_investment[feasibility]']").on("change", function() {
+        App.ValuationBudgetInvestmentForm.showAllFields();
+        App.ValuationBudgetInvestmentForm.showFeasibilityFields();
+      });
+    },
+    initialize: function() {
+      App.ValuationBudgetInvestmentForm.showFeasibilityFields();
+      App.ValuationBudgetInvestmentForm.showFeasibilityFieldsOnChange();
+    }
+  };
+}).call(this);

--- a/app/controllers/custom/admin/budget_investments_controller.rb
+++ b/app/controllers/custom/admin/budget_investments_controller.rb
@@ -1,8 +1,17 @@
 require_dependency Rails.root.join("app", "controllers", "admin", "budget_investments_controller").to_s
 
 class Admin::BudgetInvestmentsController
-
   before_action :load_investment, only: [:show, :edit, :update, :toggle_selection, :toggle_winner]
+
+  BULK_ACTIONS = %w[
+    visible_to_valuators_bulk
+    selected_bulk
+    winner_bulk
+  ].freeze
+
+  def bulk_actions
+    send(params[:button]) if params[:button].in?(BULK_ACTIONS)
+  end
 
   def toggle_winner
     authorize! :toggle_winner, @investment
@@ -12,11 +21,53 @@ class Admin::BudgetInvestmentsController
   end
 
   private
-  
+
     def allowed_params
       attributes = [:external_url, :heading_id, :administrator_id, :tag_list,
                     :valuation_tag_list, :incompatible, :visible_to_valuators, :selected, :not_selected, :supported,
                     :milestone_tag_list, valuator_ids: [], valuator_group_ids: []]
       [*attributes, translation_params(Budget::Investment)]
+    end
+
+    def visible_to_valuators_bulk
+      ids = params[:investment_ids]
+      if ids.present?
+        investments = Budget::Investment.where(id: ids)
+        investments.each do |investment|
+          investment.toggle :visible_to_valuators
+          investment.save!
+        end
+      end
+      redirect_to request.referer.presence || root_path
+    end
+
+    def selected_bulk
+      ids = params[:investment_ids]
+      if ids.present?
+        investments = Budget::Investment.where(id: ids)
+        investments.each do |investment|
+          next unless investment.feasible? && investment.valuation_finished
+
+          authorize! :toggle_selection, investment
+          investment.toggle :selected
+          investment.save!
+        end
+      end
+      redirect_to request.referer.presence || root_path
+    end
+
+    def winner_bulk
+      ids = params[:investment_ids]
+      if ids.present?
+        investments = Budget::Investment.where(id: ids)
+        investments.each do |investment|
+          next unless investment.selected?
+
+          authorize! :toggle_winner, investment
+          investment.toggle :winner
+          investment.save!
+        end
+      end
+      redirect_to request.referer.presence || root_path
     end
 end

--- a/app/controllers/custom/admin/budget_investments_controller.rb
+++ b/app/controllers/custom/admin/budget_investments_controller.rb
@@ -1,10 +1,22 @@
 require_dependency Rails.root.join("app", "controllers", "admin", "budget_investments_controller").to_s
 
 class Admin::BudgetInvestmentsController
-  def allowed_params
-    attributes = [:external_url, :heading_id, :administrator_id, :tag_list,
-                  :valuation_tag_list, :incompatible, :visible_to_valuators, :selected, :not_selected, :supported,
-                  :milestone_tag_list, valuator_ids: [], valuator_group_ids: []]
-    [*attributes, translation_params(Budget::Investment)]
+
+  before_action :load_investment, only: [:show, :edit, :update, :toggle_selection, :toggle_winner]
+
+  def toggle_winner
+    authorize! :toggle_winner, @investment
+    @investment.toggle :winner
+    @investment.save!
+    load_investments
   end
+
+  private
+  
+    def allowed_params
+      attributes = [:external_url, :heading_id, :administrator_id, :tag_list,
+                    :valuation_tag_list, :incompatible, :visible_to_valuators, :selected, :not_selected, :supported,
+                    :milestone_tag_list, valuator_ids: [], valuator_group_ids: []]
+      [*attributes, translation_params(Budget::Investment)]
+    end
 end

--- a/app/controllers/custom/admin/milestone_statuses_controller.rb
+++ b/app/controllers/custom/admin/milestone_statuses_controller.rb
@@ -1,5 +1,13 @@
 require_dependency Rails.root.join("app", "controllers", "admin", "milestone_statuses_controller").to_s
 
 class Admin::MilestoneStatusesController
+  include Translatable
+
   load_and_authorize_resource :status, class: "Milestone::Status"
+
+  private
+
+    def allowed_params
+      [translation_params(Milestone::Status)]
+    end
 end

--- a/app/controllers/custom/admin/system_emails_controller.rb
+++ b/app/controllers/custom/admin/system_emails_controller.rb
@@ -3,21 +3,21 @@ require_dependency Rails.root.join("app", "controllers", "admin", "system_emails
 class Admin::SystemEmailsController
   def index
     @system_emails = {
-      proposal_notification_digest:   %w[view preview_pending],
-      budget_investment_created:      %w[view edit_info],
-      budget_investment_selected:     %w[view edit_info],
-      budget_investment_unfeasible:   %w[view edit_info],
-      budget_investment_not_selected: %w[view edit_info],
-      budget_investment_unselected:   %w[view edit_info],
-      comment:                        %w[view edit_info],
-      reply:                          %w[view edit_info],
-      direct_message_for_receiver:    %w[view edit_info],
-      direct_message_for_sender:      %w[view edit_info],
-      email_verification:             %w[view edit_info],
-      user_invite:                    %w[view edit_info],
-      evaluation_comment:             %w[view edit_info]
+      proposal_notification_digest:       %w[view preview_pending],
+      budget_investment_created:          %w[view edit_info],
+      budget_investment_selected:         %w[view edit_info],
+      budget_investment_unfeasible:       %w[view edit_info],
+      budget_investment_not_selected:     %w[view edit_info],
+      budget_investment_unselected:       %w[view edit_info],
+      budget_investment_takecharge:       %w[view edit_info],
+      budget_investment_next_year_budget: %w[view edit_info],
+      comment:                            %w[view edit_info],
+      reply:                              %w[view edit_info],
+      direct_message_for_receiver:        %w[view edit_info],
+      direct_message_for_sender:          %w[view edit_info],
+      email_verification:                 %w[view edit_info],
+      user_invite:                        %w[view edit_info],
+      evaluation_comment:                 %w[view edit_info]
     }
   end
 end
-
-

--- a/app/controllers/custom/budgets/executions_controller.rb
+++ b/app/controllers/custom/budgets/executions_controller.rb
@@ -12,8 +12,7 @@ class Budgets::ExecutionsController
         base = base.with_milestone_status_id(params[:status])
         base.uniq.group_by(&:heading)
       else
-        base.uniq.group_by(&:heading)
+        base.distinct.group_by(&:heading)
       end
     end
 end
-

--- a/app/controllers/custom/budgets/investments_controller.rb
+++ b/app/controllers/custom/budgets/investments_controller.rb
@@ -8,7 +8,7 @@ class Budgets::InvestmentsController
   before_action :load_votes, only: [:index, :show]
   before_action :load_categories, only: [:index, :new, :create, :vote, :unvote, :edit, :update]
 
-  valid_filters = %w[not_unfeasible feasible unfeasible unselected selected winners not_selected]
+  valid_filters = %w[not_unfeasible feasible unfeasible unselected selected winners not_selected takecharged included_next_year_budget]
   has_filters valid_filters, only: [:index, :show, :suggest]
 
   def index
@@ -23,7 +23,6 @@ class Budgets::InvestmentsController
     @tag_cloud = tag_cloud
     @remote_translations = detect_remote_translations(@investments)
   end
-
 
   def unvote
     @investment.register_selection_vote_and_unvote(current_user, "no")

--- a/app/controllers/custom/budgets/status_executions_controller.rb
+++ b/app/controllers/custom/budgets/status_executions_controller.rb
@@ -1,0 +1,30 @@
+module Budgets
+  class StatusExecutionsController < ApplicationController
+    before_action :load_budget
+
+    authorize_resource :budget
+
+    def show
+      authorize! :read_executions, @budget
+      @statuses = Milestone::Status.all
+      @investments = investments_ordered_alphabetically
+    end
+
+    private
+
+      def investments
+        base = @budget.investments.winners
+        base = base.joins(milestones: :translations).includes(:milestones)
+        base = base.tagged_with(params[:milestone_tag]) if params[:milestone_tag].present?
+        base.distinct
+      end
+
+      def load_budget
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
+      end
+
+      def investments_ordered_alphabetically
+        investments.sort_by(&:title)
+      end
+  end
+end

--- a/app/controllers/custom/valuation/budget_investments_controller.rb
+++ b/app/controllers/custom/valuation/budget_investments_controller.rb
@@ -1,6 +1,6 @@
 require_dependency Rails.root.join("app", "controllers", "valuation", "budget_investments_controller").to_s
 
-class Valuation::BudgetInvestmentsController < Valuation::BaseController
+class Valuation::BudgetInvestmentsController
   def valuate
     if valid_price_params? && @investment.update(valuation_params)
       if @investment.unfeasible_email_pending?
@@ -9,6 +9,14 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
 
       if @investment.not_selected_email_pending?
         @investment.send_not_selected_email
+      end
+
+      if @investment.takecharge_email_pending?
+        @investment.send_takecharge_email
+      end
+
+      if @investment.next_year_budget_email_pending?
+        @investment.send_next_year_budget_email
       end
 
       Activity.log(current_user, :valuate, @investment)
@@ -40,6 +48,8 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
         :price, :price_first_year, :price_explanation,
         :feasibility, :unfeasibility_explanation,
         :not_selected_explanation,
+        :takecharge_explanation,
+        :next_year_budget_explanation,
         :duration, :valuation_finished
       ]
     end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -35,7 +35,8 @@ module BudgetsHelper
     {
       results: t("budgets.results.link"),
       stats: t("stats.budgets.link"),
-      executions: t("budgets.executions.link")
+      executions: t("budgets.executions.link"),
+      status_executions: t("budgets.status_executions.link")
     }.select { |section, _| can?(:"read_#{section}", budget) }.map do |section, text|
       {
         text: text,

--- a/app/helpers/milestones_helper.rb
+++ b/app/helpers/milestones_helper.rb
@@ -13,4 +13,14 @@ module MilestonesHelper
         tag.p(text, class: "progress-meter-text")
     end
   end
+
+  def milestone_status_percentage(status_kind)
+    percentage = {
+      drafting: 25,
+      processing: 50,
+      execution: 75,
+      executed: 100
+    }
+    percentage[status_kind.to_sym]
+  end
 end

--- a/app/mailers/custom/mailer.rb
+++ b/app/mailers/custom/mailer.rb
@@ -7,7 +7,33 @@ class Mailer
     @email_to = @author.email
 
     with_user(@author) do
-      mail(to: @email_to, subject: t('mailers.budget_investment_not_selected.subject', code: @investment.code))
+      mail(to: @email_to, subject: t("mailers.budget_investment_not_selected.subject", code: @investment.code))
+    end
+  end
+
+  def budget_investment_takecharge(investment)
+    @investment = investment
+    @author = investment.author
+    @email_to = @author.email
+
+    with_user(@author) do
+      mail(
+        to: @email_to,
+        subject: t("mailers.budget_investment_takecharge.subject", code: @investment.code)
+      )
+    end
+  end
+
+  def budget_investment_next_year_budget(investment)
+    @investment = investment
+    @author = investment.author
+    @email_to = @author.email
+
+    with_user(@author) do
+      mail(
+        to: @email_to,
+        subject: t("mailers.budget_investment_next_year_budget.subject", code: @investment.code)
+      )
     end
   end
 end

--- a/app/models/custom/abilities/administrator.rb
+++ b/app/models/custom/abilities/administrator.rb
@@ -1,0 +1,146 @@
+module Abilities
+  class Administrator
+    include CanCan::Ability
+
+    def initialize(user)
+      merge Abilities::Moderation.new(user)
+      merge Abilities::SDG::Manager.new(user)
+
+      can :restore, Comment
+      cannot :restore, Comment, hidden_at: nil
+
+      can :restore, Debate
+      cannot :restore, Debate, hidden_at: nil
+
+      can :restore, Proposal
+      cannot :restore, Proposal, hidden_at: nil
+
+      can :create, Legislation::Proposal
+      can :show, Legislation::Proposal
+      can :proposals, ::Legislation::Process
+
+      can :restore, Legislation::Proposal
+      cannot :restore, Legislation::Proposal, hidden_at: nil
+
+      can :restore, Budget::Investment
+      cannot :restore, Budget::Investment, hidden_at: nil
+
+      can :restore, User
+      cannot :restore, User, hidden_at: nil
+
+      can :confirm_hide, Comment
+      cannot :confirm_hide, Comment, hidden_at: nil
+
+      can :confirm_hide, Debate
+      cannot :confirm_hide, Debate, hidden_at: nil
+
+      can :confirm_hide, Proposal
+      cannot :confirm_hide, Proposal, hidden_at: nil
+
+      can :confirm_hide, Legislation::Proposal
+      cannot :confirm_hide, Legislation::Proposal, hidden_at: nil
+
+      can :confirm_hide, Budget::Investment
+      cannot :confirm_hide, Budget::Investment, hidden_at: nil
+
+      can :confirm_hide, User
+      cannot :confirm_hide, User, hidden_at: nil
+
+      can :mark_featured, Debate
+      can :unmark_featured, Debate
+
+      can :comment_as_administrator, [Debate, Comment, Proposal, Poll, Poll::Question,
+                                      Budget::Investment, Legislation::Question,
+                                      Legislation::Proposal, Legislation::Annotation, Topic]
+
+      can [:search, :create, :index, :destroy, :update], ::Administrator
+      can [:search, :create, :index, :destroy], ::Moderator
+      can [:search, :show, :update, :create, :index, :destroy, :summary], ::Valuator
+      can [:search, :create, :index, :destroy], ::Manager
+      can [:create, :read, :destroy], ::SDG::Manager
+      can [:search, :index], ::User
+
+      can :manage, Dashboard::Action
+
+      can [:index, :read, :create, :update, :destroy], Budget
+      can :publish, Budget, id: Budget.drafting.ids
+      can :calculate_winners, Budget, &:reviewing_ballots?
+      can :read_results, Budget do |budget|
+        budget.balloting_finished? && budget.has_winning_investments?
+      end
+
+      can [:read, :create, :update, :destroy], Budget::Group
+      can [:read, :create, :update, :destroy], Budget::Heading
+      can [:hide, :admin_update, :toggle_selection], Budget::Investment
+      can [:toggle_winner], Budget::Investment, budget: { phase: ["reviewing_ballots", "finished"] }
+      can [:valuate, :comment_valuation], Budget::Investment
+      cannot [:admin_update, :toggle_selection, :valuate, :comment_valuation],
+             Budget::Investment, budget: { phase: "finished" }
+
+      can :create, Budget::ValuatorAssignment
+
+      can :read_admin_stats, Budget, &:balloting_or_later?
+
+      can [:search, :update, :create, :index, :destroy], Banner
+
+      can [:index, :create, :update, :destroy], Geozone
+
+      can [:read, :create, :update, :destroy, :booth_assignments], Poll
+      can [:read, :create, :update, :destroy, :available], Poll::Booth
+      can [:search, :create, :index, :destroy], ::Poll::Officer
+      can [:create, :destroy, :manage], ::Poll::BoothAssignment
+      can [:create, :destroy], ::Poll::OfficerAssignment
+      can :read, Poll::Question
+      can [:create], Poll::Question do |question|
+        question.poll.blank? || !question.poll.started?
+      end
+      can [:update, :destroy], Poll::Question do |question|
+        !question.poll.started?
+      end
+      can [:read, :order_answers], Poll::Question::Answer
+      can [:create, :update, :destroy], Poll::Question::Answer do |answer|
+        can?(:update, answer.question)
+      end
+      can :read, Poll::Question::Answer::Video
+      can [:create, :update, :destroy], Poll::Question::Answer::Video do |video|
+        can?(:update, video.answer)
+      end
+      can [:destroy], Image do |image|
+        image.imageable_type == "Poll::Question::Answer" && can?(:update, image.imageable)
+      end
+
+      can :manage, SiteCustomization::Page
+      can :manage, SiteCustomization::Image
+      can :manage, SiteCustomization::ContentBlock
+      can :manage, Widget::Card
+
+      can :access, :ckeditor
+      can :manage, Ckeditor::Picture
+
+      can [:read, :debate, :draft_publication, :allegations, :result_publication,
+           :milestones], Legislation::Process
+      can [:create, :update, :destroy], Legislation::Process
+      can [:manage], ::Legislation::DraftVersion
+      can [:manage], ::Legislation::Question
+      can [:manage], ::Legislation::Proposal
+      cannot :comment_as_moderator,
+             [::Legislation::Question, Legislation::Annotation, ::Legislation::Proposal]
+
+      can [:create], Document
+      can [:destroy], Document do |document|
+        document.documentable_type == "Poll::Question::Answer" && can?(:update, document.documentable)
+      end
+      can [:create, :destroy], DirectUpload
+
+      can [:deliver], Newsletter, hidden_at: nil
+      can [:manage], Dashboard::AdministratorTask
+
+      can :manage, LocalCensusRecord
+      can [:create, :read], LocalCensusRecords::Import
+
+      if Rails.application.config.multitenancy && Tenant.default?
+        can [:create, :read, :update, :hide, :restore], Tenant
+      end
+    end
+  end
+end

--- a/app/models/custom/abilities/budget_manager.rb
+++ b/app/models/custom/abilities/budget_manager.rb
@@ -12,8 +12,9 @@ module Abilities
       can [:read], Budget::Heading
       can [:hide, :admin_update, :toggle_selection], Budget::Investment
       can [:valuate, :comment_valuation], Budget::Investment
+      can [:toggle_winner], Budget::Investment, budget: { phase: ["reviewing_ballots", "finished"] }
       cannot [:admin_update, :toggle_selection, :valuate, :comment_valuation],
-        Budget::Investment, budget: { phase: "finished" }
+             Budget::Investment, budget: { phase: "finished" }
 
       can :create, Budget::ValuatorAssignment
     end

--- a/app/models/custom/abilities/everyone.rb
+++ b/app/models/custom/abilities/everyone.rb
@@ -1,0 +1,37 @@
+module Abilities
+  class Everyone
+    include CanCan::Ability
+
+    def initialize(user)
+      can [:read, :map], Debate
+      can [:read, :map, :summary, :share], Proposal
+      can :read, Comment
+      can :read, Poll
+      can :results, Poll, id: Poll.expired.results_enabled.not_budget.ids
+      can :stats, Poll, id: Poll.expired.stats_enabled.not_budget.ids
+      can :read, Poll::Question
+      can :read, User
+      can [:read, :welcome], Budget
+      can [:read], Budget
+      can [:read], Budget::Group
+      can [:read, :print], Budget::Investment
+      can :read_results, Budget, id: Budget.finished.results_enabled.ids
+      can :read_stats, Budget, id: Budget.valuating_or_later.stats_enabled.ids
+      can [:read_executions], Budget, phase: "finished"
+      can [:read_status_executions], Budget do |budget|
+        budget.phase == "finished" && budget.status_executions_enabled?
+      end
+      can [:read, :debate, :draft_publication, :allegations, :result_publication,
+           :proposals, :milestones], Legislation::Process, published: true
+      can :summary, Legislation::Process,
+          id: Legislation::Process.past.published.where(result_publication_enabled: true).ids
+      can [:read, :changes, :go_to_version], Legislation::DraftVersion
+      can [:read], Legislation::Question
+      can [:read, :share], Legislation::Proposal
+      can [:search, :comments, :read, :create, :new_comment], Legislation::Annotation
+
+      can [:read, :help], ::SDG::Goal
+      can :read, ::SDG::Phase
+    end
+  end
+end

--- a/app/models/custom/budget.rb
+++ b/app/models/custom/budget.rb
@@ -1,0 +1,30 @@
+require_dependency Rails.root.join("app", "models", "budget").to_s
+
+class Budget
+  def self.change_phase
+    change_active_phases
+  end
+
+  private
+
+    def self.change_active_phases
+      active_budgets.map do |budget|
+        previous_phase = budget.phase
+        next_phase = budget.published_phases.find do |phase|
+          I18n.l(phase.starts_at.to_date) == I18n.l(Time.zone.now.to_date)
+        end
+        if next_phase.present?
+          budget.phase = next_phase.kind
+          if budget.save
+            message = I18n.t("budget_change_active_phases.success",
+                            budget_name: budget.name,
+                            previous_phase: I18n.t("budgets.phase.#{previous_phase}"),
+                            next_phase: I18n.t("budgets.phase.#{next_phase.kind}"))
+            Mailer.budget_change_active_phases(self, message).deliver_later
+          else
+            Mailer.budget_change_active_phases(self, I18n.t("budget_change_active_phases.error")).deliver_later
+          end
+        end
+      end
+    end
+end

--- a/app/models/custom/budget/investment.rb
+++ b/app/models/custom/budget/investment.rb
@@ -4,6 +4,7 @@ require_dependency Rails.root.join('app', 'models', 'budget', 'investment').to_s
 class Budget
   class Investment
 
+    before_save :set_visible_to_valuators
     scope :not_selected, -> { where(feasibility: "not_selected") }
     # NOTE: This scope includes not_selected because is a filter used by default
     scope :not_unfeasible, -> { where.not(feasibility: ["unfeasible", "not_selected", "takecharge", "next_year_budget"]) }
@@ -152,5 +153,15 @@ class Budget
     def should_show_not_selected_explanation?
       not_selected? && valuation_finished? && not_selected_explanation.present?
     end
+
+    private
+
+      def set_visible_to_valuators
+        self.visible_to_valuators = valuators.any? unless changed.include?("visible_to_valuators")
+
+        if valuation_finished && feasibility == "feasible" && !changed.include?("selected")
+          self.selected = true
+        end
+      end
   end
 end

--- a/app/models/custom/milestone/status.rb
+++ b/app/models/custom/milestone/status.rb
@@ -1,0 +1,9 @@
+require_dependency Rails.root.join("app", "models", "milestone", "status").to_s
+
+class Milestone::Status
+  translates :name, touch: true
+  translates :description, touch: true
+  include Globalizable
+
+  validates_translation :name, presence: true
+end

--- a/app/models/custom/report.rb
+++ b/app/models/custom/report.rb
@@ -1,0 +1,5 @@
+require_dependency Rails.root.join("app", "models", "report").to_s
+
+class Report < ApplicationRecord
+  KINDS = %i[results stats advanced_stats status_executions].freeze
+end

--- a/app/views/custom/admin/budget_investments/_investments.html.erb
+++ b/app/views/custom/admin/budget_investments/_investments.html.erb
@@ -9,7 +9,7 @@
 <% if @investments.any? %>
   <h3 class="inline-block"><%= page_entries_info @investments %></h3>
   <%= render "admin/shared/columns_selector",
-        cookie: "investments-columns", default: %w[id title supports min_supports admin valuator geozone feasibility price valuation_finished visible_to_valuators selected incompatible] %>
+        cookie: "investments-columns", default: %w[id title supports min_supports admin valuator geozone feasibility price valuation_finished visible_to_valuators selected winner incompatible] %>
   <br>
 
   <%= render "filters_description", i18n_namespace: "admin.budget_investments.index" %>
@@ -42,6 +42,7 @@
         </th>
         <th data-field="selected"><%= t("admin.budget_investments.index.list.selected") %></th>
         <% if params[:advanced_filters]&.include?("selected") %>
+          <th data-field="winner"><%= t("admin.budget_investments.index.list.winner") %></th>
           <th data-field="incompatible"><%= t("admin.budget_investments.index.list.incompatible") %></th>
         <% end %>
       </tr>

--- a/app/views/custom/admin/budget_investments/_investments.html.erb
+++ b/app/views/custom/admin/budget_investments/_investments.html.erb
@@ -14,48 +14,57 @@
 
   <%= render "filters_description", i18n_namespace: "admin.budget_investments.index" %>
 
-  <table class="table-for-mobile column-selectable">
-    <thead>
-      <tr>
-        <th><%= link_to_investments_sorted_by :id %></th>
-        <th data-field="title"><%= link_to_investments_sorted_by :title %></th>
-        <th data-field="supports"><%= link_to_investments_sorted_by :supports %></th>
-        <th data-field="min_supports"><%= t("admin.budget_investments.index.list.min_supports") %></th>
-        <th data-field="admin"><%= t("admin.budget_investments.index.list.admin") %></th>
-        <th data-field="author">
-          <%= t("admin.budget_investments.index.list.author") %>
-        </th>
-        <th data-field="valuator">
-          <%= t("admin.budget_investments.index.list.valuation_group") %> /
-          <%= t("admin.budget_investments.index.list.valuator") %>
-        </th>
-        <th data-field="geozone"><%= t("admin.budget_investments.index.list.geozone") %></th>
-        <th data-field="feasibility"><%= t("admin.budget_investments.index.list.feasibility") %></th>
-        <% if @budget.show_money? %>
-          <th data-field="price"><%= t("admin.budget_investments.index.list.price") %></th>
-        <% end %>
-        <th data-field="valuation_finished">
-          <%= t("admin.budget_investments.index.list.valuation_finished") %>
-        </th>
-        <th data-field="visible_to_valuators">
-          <%= t("admin.budget_investments.index.list.visible_to_valuators") %>
-        </th>
-        <th data-field="selected"><%= t("admin.budget_investments.index.list.selected") %></th>
-        <% if params[:advanced_filters]&.include?("selected") %>
-          <th data-field="winner"><%= t("admin.budget_investments.index.list.winner") %></th>
-          <th data-field="incompatible"><%= t("admin.budget_investments.index.list.incompatible") %></th>
-        <% end %>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% @investments.each do |investment| %>
-        <tr id="<%= dom_id(investment) %>" class="budget_investment">
-          <%= render "/admin/budget_investments/select_investment", investment: investment %>
+  <%= form_for([:admin, @budget], url: bulk_actions_admin_budget_budget_investments_path(@budget), html: { id: 'bulk-actions-form' }) do |f| %>
+    <button type="button" id="select-all" class="button small"><%= t("admin.budget_investments.index.select_all")%></button>
+    <%= button_tag t("admin.budget_investments.index.visible_to_valuators_bulk"), type: "submit", class: "button small", value: "visible_to_valuators_bulk" %>
+    <%= button_tag t("admin.budget_investments.index.selected_bulk"), type: "submit", class: "button small", value: "selected_bulk" %>
+    <% if params[:advanced_filters]&.include?("selected") && @budget.phase.in?(["reviewing_ballots", "finished"]) %>
+      <%= button_tag t("admin.budget_investments.index.winner_bulk"), type: "submit", class: "button small", value: "winner_bulk" %>
+    <% end %>
+    <table class="table-for-mobile column-selectable">
+      <thead>
+        <tr>
+          <th></th>
+          <th><%= link_to_investments_sorted_by :id %></th>
+          <th data-field="title"><%= link_to_investments_sorted_by :title %></th>
+          <th data-field="supports"><%= link_to_investments_sorted_by :supports %></th>
+          <th data-field="min_supports"><%= t("admin.budget_investments.index.list.min_supports") %></th>
+          <th data-field="admin"><%= t("admin.budget_investments.index.list.admin") %></th>
+          <th data-field="author">
+            <%= t("admin.budget_investments.index.list.author") %>
+          </th>
+          <th data-field="valuator">
+            <%= t("admin.budget_investments.index.list.valuation_group") %> /
+            <%= t("admin.budget_investments.index.list.valuator") %>
+          </th>
+          <th data-field="geozone"><%= t("admin.budget_investments.index.list.geozone") %></th>
+          <th data-field="feasibility"><%= t("admin.budget_investments.index.list.feasibility") %></th>
+          <% if @budget.show_money? %>
+            <th data-field="price"><%= t("admin.budget_investments.index.list.price") %></th>
+          <% end %>
+          <th data-field="valuation_finished">
+            <%= t("admin.budget_investments.index.list.valuation_finished") %>
+          </th>
+          <th data-field="visible_to_valuators">
+            <%= t("admin.budget_investments.index.list.visible_to_valuators") %>
+          </th>
+          <th data-field="selected"><%= t("admin.budget_investments.index.list.selected") %></th>
+          <% if params[:advanced_filters]&.include?("selected") %>
+            <th data-field="winner"><%= t("admin.budget_investments.index.list.winner") %></th>
+            <th data-field="incompatible"><%= t("admin.budget_investments.index.list.incompatible") %></th>
+          <% end %>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+
+      <tbody>
+        <% @investments.each do |investment| %>
+          <tr id="<%= dom_id(investment) %>" class="budget_investment">
+            <%= render "/admin/budget_investments/select_investment", investment: investment %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 
   <%= paginate @investments %>
 <% else %>

--- a/app/views/custom/admin/budget_investments/_search_form.html.erb
+++ b/app/views/custom/admin/budget_investments/_search_form.html.erb
@@ -12,7 +12,7 @@
     <div class="small-12 column">
       <div class="advanced-filters-content">
         <% %w[feasible selected undecided unfeasible without_admin without_valuator under_valuation
-              valuation_finished supported winners not_selected].each do |filter| %>
+              valuation_finished supported winners takecharged included_next_year_budget not_selected].each do |filter| %>
           <div class="filter">
             <%= check_box_tag "advanced_filters[]", filter, params[:advanced_filters].index(filter), id: "advanced_filters_#{filter}" %>
             <%= label_tag "advanced_filters[#{filter}]", t("admin.budget_investments.index.filters.#{filter}") %>

--- a/app/views/custom/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/custom/admin/budget_investments/_select_investment.html.erb
@@ -107,6 +107,42 @@
 </td>
 
 <% if params[:advanced_filters]&.include?("selected") %>
+  <td id="winner" class="small text-center" data-field="winner">
+    <% if investment.selected? && investment.winner? %>
+        <%= link_to_if can?(:toggle_winner, investment),
+                      t("admin.budget_investments.index.winner"),
+                      toggle_winner_admin_budget_budget_investment_path(
+                        @budget,
+                        investment,
+                        filter: params[:filter],
+                        sort_by: params[:sort_by],
+                        min_total_supports: params[:min_total_supports],
+                        max_total_supports: params[:max_total_supports],
+                        advanced_filters: params[:advanced_filters],
+                        page: params[:page]
+                      ),
+                      method: :patch,
+                      remote: true,
+                      class: "button small expanded" %>
+    <% elsif investment.selected? %>
+      <% if can?(:toggle_winner, investment) %>
+        <%= link_to t("admin.budget_investments.index.win"),
+                    toggle_winner_admin_budget_budget_investment_path(
+                      @budget,
+                      investment,
+                      filter: params[:filter],
+                      sort_by: params[:sort_by],
+                      min_total_supports: params[:min_total_supports],
+                      max_total_supports: params[:max_total_supports],
+                      advanced_filters: params[:advanced_filters],
+                      page: params[:page]
+                    ),
+                    method: :patch,
+                    remote: true,
+                    class: "button small hollow expanded" %>
+      <% end %>
+    <% end %>
+  </td>
   <td class="small text-center" data-field="incompatible">
     <%= investment.incompatible? ? t("shared.yes") : t("shared.no") %>
   </td>

--- a/app/views/custom/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/custom/admin/budget_investments/_select_investment.html.erb
@@ -1,3 +1,7 @@
+<td class="small text-center">
+  <%= check_box_tag "investment_ids[]", investment.id %>
+</td>
+
 <td class="text-right" data-field="id">
   <strong><%= investment.id %></strong>
 </td>

--- a/app/views/custom/admin/budget_investments/toggle_winner.js.erb
+++ b/app/views/custom/admin/budget_investments/toggle_winner.js.erb
@@ -1,0 +1,1 @@
+$("#<%= dom_id(@investment) %>").html("<%= j render("select_investment", investment: @investment) %>").trigger("inserted");

--- a/app/views/custom/admin/milestone_statuses/_form.html.erb
+++ b/app/views/custom/admin/milestone_statuses/_form.html.erb
@@ -1,0 +1,19 @@
+<%= render "shared/globalize_locales", resource: @status %>
+
+<%= translatable_form_for [:admin, @status] do |f| %>
+  <%= render "shared/errors", resource: @status %>
+
+  <div class="row">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="column">
+        <%= translations_form.text_field :name %>
+        <%= translations_form.text_area :description %>
+      </div>
+    <% end %>
+  </div>
+
+
+  <div class="margin-top">
+    <%= f.submit class: "button success" %>
+  </div>
+<% end %>

--- a/app/views/custom/admin/milestone_statuses/index.html.erb
+++ b/app/views/custom/admin/milestone_statuses/index.html.erb
@@ -1,0 +1,37 @@
+<h2 class="inline-block"><%= t("admin.statuses.index.title") %></h2>
+
+<%= link_to t("admin.statuses.index.new_status"),
+            new_admin_milestone_status_path,
+            class: "button float-right margin-right" %>
+
+<% if @statuses.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("admin.statuses.index.table_name") %></th>
+        <th><%= t("admin.statuses.index.table_description") %></th>
+        <th><%= t("admin.statuses.index.table_actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @statuses.each do |status| %>
+        <tr id="<%= dom_id(status) %>" class="milestone_status">
+          <td>
+            <%= status.name %>
+          </td>
+          <td>
+            <%= status.description %>
+          </td>
+          <td>
+            <% actions = status.kind ? [:edit] : nil %>
+            <%= render Admin::TableActionsComponent.new(status, actions: actions) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div data-alert class="callout primary margin-top clear">
+    <%= t("admin.statuses.index.empty_statuses") %>
+  </div>
+<% end %>

--- a/app/views/custom/admin/shared/_show_results_fields.html.erb
+++ b/app/views/custom/admin/shared/_show_results_fields.html.erb
@@ -1,0 +1,12 @@
+<fieldset aria-describedby="results_and_stats_reminder">
+  <legend><%= t("admin.shared.show_results_and_stats") %></legend>
+
+  <p class="help-text" id="results_and_stats_reminder">
+    <%= t("admin.shared.results_and_stats_reminder") %>
+  </p>
+
+  <%= form.check_box :results_enabled %>
+  <%= form.check_box :stats_enabled %>
+  <%= form.check_box :advanced_stats_enabled %>
+  <%= form.check_box :status_executions_enabled %>
+</fieldset>

--- a/app/views/custom/budgets/_subnav.html.erb
+++ b/app/views/custom/budgets/_subnav.html.erb
@@ -1,0 +1,17 @@
+<div class="row margin-top">
+  <div class="small-12 column">
+    <ul class="tabs">
+      <% budget_subnav_items_for(budget).each do |item| %>
+        <% if item[:active] %>
+          <li class="tabs-title is-active">
+            <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
+
+            <%= link_to item[:text], item[:url], class: "is-active" %>
+          </li>
+        <% else %>
+          <li class="tabs-title"><%= link_to item[:text], item[:url] %></li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/custom/budgets/investments/_investment.html.erb
+++ b/app/views/custom/budgets/investments/_investment.html.erb
@@ -29,7 +29,7 @@
         </div>
       </div>
 
-      <% unless investment.unfeasible? || investment.not_selected? %> <%# Custom part%>
+      <% unless investment.unfeasible? || investment.not_selected? || investment.takecharge? || investment.next_year_budget?%> <%# Custom part%>
 
         <% if investment.should_show_votes? %>
           <div id="<%= dom_id(investment) %>_votes"

--- a/app/views/custom/budgets/investments/index.html.erb
+++ b/app/views/custom/budgets/investments/index.html.erb
@@ -36,6 +36,41 @@
             <%= t("budgets.investments.index.unfeasible_text") %>
           </div>
         </div>
+      <% elsif @current_filter == "unselected" %>
+        <div class="small-12 margin-bottom">
+          <h2><%= t("budgets.investments.index.unselected") %></h2>
+          <div class="callout primary margin">
+              <%= t("budgets.investments.index.unselected_text") %>
+          </div>
+        </div>
+      <% elsif @current_filter == "takecharged" %>
+        <div class="small-12 margin-bottom">
+          <h2><%= t("budgets.investments.index.takecharged") %></h2>
+          <div class="callout primary margin">
+              <%= t("budgets.investments.index.takecharged_text") %>
+          </div>
+        </div>
+      <% elsif @current_filter == "included_next_year_budget" %>
+        <div class="small-12 margin-bottom">
+          <h2><%= t("budgets.investments.index.included_next_year_budget") %></h2>
+          <div class="callout primary margin">
+              <%= t("budgets.investments.index.included_next_year_budget_text") %>
+          </div>
+        </div>
+      <% elsif @current_filter == "selected" %>
+        <div class="small-12 margin-bottom">
+          <h2><%= t("budgets.investments.index.selected") %></h2>
+          <div class="callout primary margin">
+              <%= t("budgets.investments.index.selected_text") %>
+          </div>
+        </div>
+      <% elsif @current_filter == "not_selected" %>
+        <div class="small-12 margin-bottom">
+          <h2><%= t("budgets.investments.index.not_selected") %></h2>
+          <div class="callout primary margin">
+              <%= t("budgets.investments.index.not_selected_text") %>
+          </div>
+        </div>
       <% elsif @heading.present? %>
         <div class="row">
           <div class="small-12 column">

--- a/app/views/custom/budgets/results/show.html.erb
+++ b/app/views/custom/budgets/results/show.html.erb
@@ -67,6 +67,12 @@
       <%= link_to budget_investments_path(@budget, heading_id: @heading, filter: "unfeasible") do %>
         <small><%= t("budgets.results.unfeasible_investment_proyects") %></small>
       <% end %><br>
+      <%= link_to budget_investments_path(@budget, heading_id: @heading, filter: "takecharged") do %>
+        <small><%= t("budgets.results.takecharged_investment_proyects") %></small>
+      <% end %><br>
+      <%= link_to budget_investments_path(@budget, heading_id: @heading, filter: "nextyearbudget") do %>
+        <small><%= t("budgets.results.included_next_year_budget_investment_proyects") %></small>
+      <% end %><br>
       <%= link_to budget_investments_path(@budget, heading_id: @heading, filter: "not_selected") do %>
         <small><%= t("budgets.results.not_selected_investment_proyects") %></small>
       <% end %><br>

--- a/app/views/custom/budgets/status_executions/_investments.html.erb
+++ b/app/views/custom/budgets/status_executions/_investments.html.erb
@@ -1,0 +1,44 @@
+<table id="status_executions">
+  <thead>
+    <tr>
+      <th><% t("budget.status_executions.table.id")%></th>
+      <th><% t("budget.status_executions.table.heading_name")%></th>
+      <th><% t("budget.status_executions.table.title")%></th>
+      <th><% t("budget.status_executions.table.price")%></th>
+      <th><% t("budget.status_executions.table.milestone_status.name")%></th>
+      <th><% t("budget.status_executions.table.milestone_status.kind")%></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @investments.each do |investment| %>
+      <tr id="<%= dom_id(investment) %>" class="investment">
+        <td>
+          <%= investment.id %>
+        </td>
+        <td>
+          <%= investment.heading.name %>
+        </td>
+        <td>
+          <%= link_to investment.title,
+                      budget_investment_path(@budget, investment, anchor: "tab-milestones") %>
+        </td>
+        <td>
+          <%= investment.formatted_price %>
+        </td>
+        <td>
+          <%= investment.milestone_status.name %>
+        </td>
+        <td>
+          <% if investment.milestone_status.kind %>
+            <strong>
+              <%= number_to_stats_percentage(milestone_status_percentage(investment.milestone_status.kind)) %>
+            </strong>
+            <div class="progress" tabindex="0">
+              <span class="progress-meter" style="width: <%= milestone_status_percentage(investment.milestone_status.kind) %>%"></span>
+            </div>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/custom/budgets/status_executions/show.html.erb
+++ b/app/views/custom/budgets/status_executions/show.html.erb
@@ -1,0 +1,62 @@
+<% provide :title, t("budgets.executions.page_title", budget: @budget.name) %>
+<% content_for :meta_description do %><%= @budget.description_for_phase("finished") %><% end %>
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags",
+           social_url: budget_executions_url(@budget),
+           social_title: @budget.name,
+           social_description: @budget.description_for_phase("finished") %>
+<% end %>
+
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: budget_executions_url(@budget) %>
+<% end %>
+
+<div class="budgets-stats">
+  <div class="expanded no-margin-top padding header">
+    <div class="row">
+      <div class="small-12 column">
+        <%= back_link_to budget_path(@budget) %>
+        <h2 class="margin-top">
+          <%= t("budgets.status_executions.heading") %><br>
+          <span><%= @budget.name %></span>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render "budgets/subnav", budget: @budget %>
+
+ <% if @investments.any? %>
+  <div id="advanced_statistics" class="participation-stats">
+    <h3 class="section-title"><%=t("budgets.status_executions.link")%></h3>
+    <div id="total_investments" class="stats-group">
+      <%= number_with_info_tags(
+        @investments.count,
+        t("stats.budgets.total_investments"),
+        html_class: "total-investments"
+      ) %>
+
+      <%= number_with_info_tags(@budget.investments.milestone_drafting.count,
+                                t("budgets.milestone.statuses.drafting")) %>
+      <%= number_with_info_tags(@budget.investments.milestone_processing.count,
+                                t("budgets.milestone.statuses.processing")) %>
+      <%= number_with_info_tags(@budget.investments.milestone_execution.count,
+                                t("budgets.milestone.statuses.execution")) %>
+      <%= number_with_info_tags(@budget.investments.milestone_executed.count,
+                                t("budgets.milestone.statuses.executed")) %>
+    </div>
+  </div>
+  <% end %>
+<div class="row">
+
+  <div class="small-12 medium-9 large-10 column">
+    <% if @investments.any? %>
+      <%= render "budgets/status_executions/investments" %>
+    <% else %>
+      <div class="callout primary clear">
+        <%= t("budgets.status_executions.no_winner_investments") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/custom/mailer/budget_investment_next_year_budget.html.erb
+++ b/app/views/custom/mailer/budget_investment_next_year_budget.html.erb
@@ -1,0 +1,22 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_next_year_budget.hi") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_next_year_budget.explanation") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; padding-left: 12px; border-left: 2px solid #ccc;">
+    <%= @investment.next_year_budget_explanation.presence || '-' %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_next_year_budget.sorry") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_next_year_budget.sincerely") %>
+  </p>
+</td>

--- a/app/views/custom/mailer/budget_investment_takecharge.html.erb
+++ b/app/views/custom/mailer/budget_investment_takecharge.html.erb
@@ -1,0 +1,22 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_takecharge.hi") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_takecharge.explanation") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; padding-left: 12px; border-left: 2px solid #ccc;">
+    <%= @investment.takecharge_explanation.presence || '-' %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_takecharge.sorry") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.budget_investment_takecharge.sincerely") %>
+  </p>
+</td>

--- a/app/views/custom/valuation/budget_investments/_dossier.html.erb
+++ b/app/views/custom/valuation/budget_investments/_dossier.html.erb
@@ -41,8 +41,7 @@
   <%= t("valuation.budget_investments.show.#{@investment.feasibility}") %>
 </p>
 
-<%= explanation_field @investment.unfeasibility_explanation if @investment.feasibility == 'unfeasible' %>
-<%= explanation_field @investment.not_selected_explanation if @investment.feasibility == 'not_selected' %>
+<%= render "/valuation/budget_investments/feasibility_explanation", investment: @investment %>
 
 <% if @investment.valuation_finished %>
   <p id="valuation">

--- a/app/views/custom/valuation/budget_investments/_dossier_form.html.erb
+++ b/app/views/custom/valuation/budget_investments/_dossier_form.html.erb
@@ -5,25 +5,37 @@
     <div class="small-12 column">
       <fieldset class="fieldset">
         <legend><%= t("valuation.budget_investments.edit.feasibility") %></legend>
-        <div class="small-3 column">
+        <div class="small-4 column">
             <span class="radio">
               <%= f.radio_button :feasibility, "undecided" %>
             </span>
         </div>
 
-        <div class="small-3 column">
+        <div class="small-4 column">
             <span class="radio">
               <%= f.radio_button :feasibility, "feasible" %>
             </span>
         </div>
 
-        <div class="small-3 column">
+        <div class="small-4 column">
             <span class="radio">
               <%= f.radio_button :feasibility, "unfeasible" %>
             </span>
         </div>
 
-        <div class="small-3 column">
+        <div class="small-4 column">
+            <span class="radio">
+              <%= f.radio_button :feasibility, "takecharge", label: t("valuation.budget_investments.edit.takecharge") %>
+            </span>
+        </div>
+
+        <div class="small-8 column">
+            <span class="radio">
+              <%= f.radio_button :feasibility, "nextyearbudget", label: t("valuation.budget_investments.edit.nextyearbudget") %>
+            </span>
+        </div>
+
+        <div class="small-12 column">
             <span class="radio">
               <%= f.radio_button :feasibility, "not_selected" %>
             </span>
@@ -51,6 +63,27 @@
     </div>
 
   </div>
+
+   <div id="takecharge_fields">
+
+    <div class="row">
+      <div class="small-12 column">
+        <%= f.text_area :takecharge_explanation, rows: 3, label: t("valuation.budget_investments.edit.feasible_explanation_html_takecharge") %>
+      </div>
+    </div>
+
+  </div>
+
+  <div id="next_year_budget_fields">
+
+    <div class="row">
+      <div class="small-12 column">
+        <%= f.text_area :next_year_budget_explanation, rows: 3, label: t("valuation.budget_investments.edit.feasible_explanation_html_next_year_budget") %>
+      </div>
+    </div>
+
+  </div>
+
 
   <div id="feasible_fields">
 
@@ -92,7 +125,9 @@
           id: "js-investment-report-alert",
           "data-alert": t("valuation.budget_investments.edit.valuation_finished_alert"),
           "data-not-feasible-alert": t("valuation.budget_investments.edit.not_feasible_alert"),
-          "data-not-selected-alert": t("valuation.budget_investments.edit.not_selected_alert") %>
+          "data-not-selected-alert": t("valuation.budget_investments.edit.not_selected_alert"),
+          "data-takecharge-alert": t("valuation.budget_investments.edit.takecharge_alert"),
+          "data-next-year-budget-alert": t("valuation.budget_investments.edit.next_year_budget_alert") %>
     </div>
   </div>
 

--- a/app/views/custom/valuation/budget_investments/_feasibility_explanation.html.erb
+++ b/app/views/custom/valuation/budget_investments/_feasibility_explanation.html.erb
@@ -1,0 +1,8 @@
+<%# Unfeasible %>
+<%= explanation_field investment.unfeasibility_explanation if investment.feasibility == "unfeasible" %>
+<%# Not selected %>
+<%= explanation_field investment.not_selected_explanation if investment.feasibility == "notselected" %>
+<%# Takecharge %>
+<%= explanation_field investment.takecharge_explanation if investment.feasibility == "takecharge" %>
+<%# Next year budget %>
+<%= explanation_field investment.next_year_budget_explanation if investment.feasibility == "nextyearbudget" %>

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -3,6 +3,7 @@ es:
     geozone_id: "Ámbito de actuación"
     results_enabled: "Mostrar resultados"
     stats_enabled: "Mostrar estadísticas"
+    status_executions_enabled: "Mostrar estado de ejecución"
     advanced_stats_enabled: "Mostrar estadísticas avanzadas"
     name: Nombre
     email: Email

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -276,6 +276,10 @@ es:
         select: Seleccionar
         winner: Ganador
         win: Ganar
+        visible_to_valuators_bulk: Marcar evaluadores como visible
+        selected_bulk: Marcar como seleccionadas
+        winner_bulk: Marcar como ganadoras
+        select_all: Seleccionar todos
         list:
           id: ID
           title: Título

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -272,8 +272,10 @@ es:
           not_selected: "No seleccionada"
           takecharge: "Asumido"
           nextyearbudget: "Previsto inclusión en presup. del próx. año"
-        selected: "Seleccionado"
-        select: "Seleccionar"
+        selected: Seleccionado
+        select: Seleccionar
+        winner: Ganador
+        win: Ganar
         list:
           id: ID
           title: Título
@@ -286,6 +288,7 @@ es:
           feasibility: Viabilidad
           valuation_finished: Ev. Fin.
           selected: Seleccionado
+          winner: Ganador
           visible_to_valuators: Mostrar a evaluadores
           author_username: Usuario autor
           incompatible: Incompatible

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -249,6 +249,8 @@ es:
           undecided: Sin decidir
           unfeasible: Inviables
           not_selected: No seleccionadas
+          takecharged: "Asumido"
+          included_next_year_budget: "Prev. inclusión en presup. del próx. año"
           min_total_supports: Apoyos mínimos
           max_total_supports: Apoyos máximos
           winners: Ganadores
@@ -268,6 +270,8 @@ es:
           unfeasible: "Inviable"
           undecided: "Sin decidir"
           not_selected: "No seleccionada"
+          takecharge: "Asumido"
+          nextyearbudget: "Previsto inclusión en presup. del próx. año"
         selected: "Seleccionado"
         select: "Seleccionar"
         list:
@@ -927,6 +931,12 @@ es:
       budget_investment_unselected:
         title: "Proyecto de gasto no seleccionado"
         description: "Enviado al autor de un proyecto de presupuestos participativos que no ha sido seleccionado para la fase de votación."
+      budget_investment_takecharge:
+        title: "Proyecto de gasto asumido"
+        description: "Enviado al autor de un proyecto de presupuestos participativos que ha sido marcado como asumido."
+      budget_investment_next_year_budget:
+        title: "Proyecto de gasto previsto para inclusión en presupuesto del próximo año"
+        description: "Enviado al autor de un proyecto de presupuestos participativos que ha sido marcado como previsto para inclusión en presupuesto del próximo año."
       comment:
         title: "Comentario"
         description: "Enviado al autor cuando recibe un comentario."

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -248,6 +248,17 @@ es:
         dates_range_invalid: "La fecha de comienzo no puede ser igual o superior a la de finalización"
         prev_phase_dates_invalid: "La fecha de inicio debe ser posterior a la fecha de inicio de la anterior fase habilitada (%{phase_name})"
         next_phase_dates_invalid: "La fecha de fin debe ser anterior a la fecha de fin de la siguiente fase habilitada (%{phase_name})"
+    milestone:
+      statuses:
+        drafting: Redacción
+        drafting_description: El área municipal responsable de la ejecución del proyecto está realizando el estudio de detalle o realizando el proyecto técnico correspondiente.
+        processing: Tramitación
+        processing_description: El proyecto técnico se encuentra en fase de gestión administrativa. Si es un contrato menor lo tramita la unidad que ejecuta el proyecto, sino se encuentra en el servicio transversal de contratación
+        execution: Ejecución
+        execution_description: El proyecto se encuentra en fase de ejecución.
+        executed: Ejecutado
+        executed_description: El proyecto ha sido ejecutado y se ha finalizado.
+
   votes:
     budget_investments:
       max_votes_per_budget_per_user_limit_reached: "Has apoyado el máximo de propuestas permitido."

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -48,6 +48,10 @@ es:
         not_selected: Ver proyectos no seleccionados en la fase de revisión interna
         unselected_title: Proyectos no seleccionados para la fase de evaluación
         unselected: Ver los proyectos no seleccionados para la fase de evaluación
+        takecharged_title: Proyectos asumidos
+        takecharged: Ver los proyectos asumidos
+        included_next_year_budget_title: Ver los proyectos previstos para su inclusión en presupuestos del próximo año
+        included_next_year_budget: Proyectos previstos para su inclusión en el presupuesto del próximo año
     phase:
       drafting: Fase de borrador (No visible para el público)
       informing: Fase de información y debates
@@ -99,6 +103,10 @@ es:
         unfeasible: Proyectos de gasto no viables
         not_selected: Proyectos de gasto no seleccionados en la fase de revisión interna
         unfeasible_text: "Los proyectos presentados deben cumplir una serie de criterios (legalidad, concreción, no superar el tope del presupuesto) para ser declarados viables y llegar hasta la fase de votación final. Todos los proyectos que no cumplen estos criterios son marcados como inviables y publicados en la siguiente lista, junto con su informe de inviabilidad."
+        takecharged: Propuestas de inversión asumidas.
+        takecharged_text: Las propuestas que ya se hayan realizado, se estén realizando en ese momento o esté prevista su realización, de forma fehaciente, en el ejercicio actual.
+        included_next_year_budget: Propuestas de inversión previstas para su inclusión en presupuestos del próximo año
+        included_next_year_budget_text: Las propuestas que los servicios tienen previstas en sus acciones a desarrollar durante el próximo año.
         by_heading: "Proyectos de gasto con ámbito: %{heading}"
         search_form:
           button: Buscar
@@ -141,6 +149,8 @@ es:
           unfeasible: "Inviables"
           unselected: "No seleccionados"
           winners: "Ganadores"
+          takecharged: "Asumidos"
+          included_next_year_budget: "Prev. inclusión en presup. del próx. año"
         orders:
           random: Aleatorios
           confidence_score: Mejor valorados
@@ -226,6 +236,8 @@ es:
       unfeasible_investment_proyects: Ver lista de proyectos de gasto inviables
       not_selected_investment_proyects: Ver el listado de propuestas no seleccionados en la fase de revisión interna
       unselected_investment_proyects: Ver lista de proyectos de gasto no seleccionados para la fase de evaluación
+      takecharged_investment_proyects: Ver lista de proyectos de gasto asumidos
+      included_next_year_budget_investment_proyects: Ver lista de proyectos de gasto previstos para su inclusión en el presupuesto del próximo año
     executions:
       link: "Seguimiento"
       page_title: "%{budget} - Seguimiento de proyectos"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -255,6 +255,31 @@ es:
         button: Buscar
         placeholder: Buscar proyectos de gasto...
         title: Buscar
+    status_executions:
+      link: "Estado de ejecución"
+      page_title: "%{budget} - Estado de ejecución de proyectos"
+      heading: "Estado de ejecución de proyectos"
+      heading_selection_title: "Ámbito de actuación"
+      no_winner_investments: "No hay proyectos de gasto ganadores en este estado"
+      filters:
+        status:
+          label: "Estado actual del proyecto"
+          all: "Todos (%{count})"
+        milestone_tag:
+          label: "Etiquetas de estado de ejecución"
+          all: "Todos (%{count})"
+      search_form:
+        button: Buscar
+        placeholder: Buscar proyectos de gasto...
+        title: Buscar
+      table:
+        id: Número de propuesta
+        heading_name: Partida
+        title: Título
+        price: Presupuesto
+        milestone_status:
+          name: Fase de ejecución
+          kind: Porcentaje desarrollo
     phases:
       errors:
         dates_range_invalid: "La fecha de comienzo no puede ser igual o superior a la de finalización"

--- a/config/locales/custom/es/mailers.yml
+++ b/config/locales/custom/es/mailers.yml
@@ -87,6 +87,18 @@ es:
       hi: "Estimado/a usuario/a"
       thanks: "Gracias de nuevo por tu participación."
       sincerely: "Atentamente"
+    budget_investment_takecharge:
+      hi: "Estimado/a usuario/a"
+      explanation: 'Su proyecto no pasa a la siguiente fase de apoyos porque ha sido asumido por el Generalitat.'
+      sincerely: "Atentamente"
+      sorry: "Gracias por tu inestimable participación."
+      subject: "Tu proyecto de gasto '%{code}' ha sido asumido por el generalitat"
+    budget_investment_next_year_budget:
+      hi: "Estimado/a usuario/a"
+      explanation: 'Su proyecto no pasa a la siguiente fase de apoyos porque está prevista su inclusión en los presupuestos del próximo año.'
+      sincerely: "Atentamente"
+      sorry: "Gracias por tu inestimable participación."
+      subject: "Tu proyecto de gasto '%{code}' está previsto para inclusión el próximo año"
     evaluation_comment:
       subject: "Nuevo comentario de evaluación"
       title: Nuevo comentario de evaluación para %{investment}

--- a/config/locales/custom/es/valuation.yml
+++ b/config/locales/custom/es/valuation.yml
@@ -49,6 +49,8 @@ es:
         unfeasible: Inviable
         not_selected: No seleccionado
         undefined: Sin definir
+        takecharge: Asumido
+        nextyearbudget: Prevista inclusión en presupuestos del próximo año
         valuation_finished: Informe finalizado
         duration: Plazo de ejecución
         responsibles: Responsables
@@ -60,7 +62,11 @@ es:
         price: "Coste (%{currency}) <small>(dato público)</small>"
         price_first_year: "Coste en el primer año (%{currency}) <small>(opcional, dato no público)</small>"
         feasibility: Viabilidad
+        takecharge: "Asumido"
+        nextyearbudget: "Prevista inclusión en presupuestos del próximo año"
         valuation_finished_alert: "¿Estás seguro/a de querer marcar este informe como completado? Una vez hecho, no se puede deshacer la acción."
+        feasible_explanation_html_takecharge: Informe de asumido <small>(en caso de que el proyecto sea ASUMIDO se mostrará esta información, dato público)</small>
+        feasible_explanation_html_next_year_budget: Informe de selección para el próximo año <small>(en caso de que el proyecto sea SELECCIONADO PARA EL PRÓXIMO AÑO se mostrará esta información, dato público)</small>
         not_feasible_alert: "Un email será enviado inmediatamente al autor del proyecto con el informe de inviabilidad."
         not_selected_alert: "Un email será enviado inmediatamente al autor del proyecto con el informe de no selección."
         save: Guardar cambios

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -167,6 +167,8 @@ val:
           undecided: Sense decidir
           unfeasible: Inviable
           not_selected: No seleccionades
+          takecharged: Assumit
+          included_next_year_budget: "Prev. inclusió en presup. del próx. any"
           min_total_supports: Avals mínims
           winners: Guanyadores
         buttons:
@@ -673,6 +675,12 @@ val:
         title: "Resum de Notificacions de Propostes"
         description: "Reuneix totes les notificacions de propostes en un únic missatge, per a evitar massa emails."
         preview_detail: "Els usuaris sols rebran les notificacions d'aquelles propostes que segueixquen"
+      budget_investment_takecharge:
+        title: "Projecte de gasto assumit"
+        description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut marcat com assumit."
+      budget_investment_next_year_budget:
+        title: "Projecte de gasto previst per a inclusió en pressupost del pròxim any"
+        description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut marcat com a previst per a inclusió en pressupost del pròxim any."
     emails_download:
       index:
         title: Descàrrega de emails

--- a/config/locales/custom/val/budgets.yml
+++ b/config/locales/custom/val/budgets.yml
@@ -186,6 +186,16 @@ val:
         dates_range_invalid: "La data d'inici no ha de ser igual o posterior a la data de fi"
         prev_phase_dates_invalid: "La data d'inici ha de ser posterior a la data d'inici de la fase anterior (%{phase_name})"
         next_phase_dates_invalid: "La data de fi ha de ser posterior a la data de fi de la seguent fase (%{phase_name})"
+    milestone:
+      statuses:
+        drafting: Redacció
+        drafting_description: "L’àrea municipal responsable de l’execució del projecte està fent l’estudi dedetall o el projecte tècnic corresponent."
+        processing: Tramitació
+        processing_description: El projecte tècnic es troba en fase de gestió administrativa. Si és un contracte menor ho tramita la unitat que executa el projecte, sinó es troba en el Servici de Contratació.
+        execution: Execució
+        execution_description: "El projecte es troba en fase d’execució."
+        executed: Executat
+        executed_description: "El projecte ha sigut executat i s’ha finalitzat."
   votes:
     budget_investments:
       max_votes_per_budget_per_user_limit_reached: "Has avalat el màxim de propostes permés."

--- a/config/locales/custom/val/budgets.yml
+++ b/config/locales/custom/val/budgets.yml
@@ -201,6 +201,28 @@ val:
         button: Cercar
         placeholder: Cercar propostes d'inversió...
         title: Cercar
+    status_executions:
+      link: "Estat d'execució"
+      page_title: "%{budget} - Estat d'execució"
+      heading: "Estat d'execució de pressupostos participatiu"
+      heading_selection_title: "Àmbit d'actuació"
+      no_winner_investments: "No hi ha propostes en aquest estat"
+      filters:
+        status:
+          label: "Estat actual del projecte"
+          all: "Tots (%{count})"
+      search_form:
+        button: Cercar
+        placeholder: Cercar propostes d'inversió...
+        title: Cercar
+      table:
+        id: Número de proposta
+        heading_name: Partida
+        title: Títol
+        price: Pressupost
+        milestone_status:
+          name: Fase d'execució
+          kind: Percentatge desenrotlle
     phases:
       errors:
         dates_range_invalid: "La data d'inici no ha de ser igual o posterior a la data de fi"

--- a/config/locales/custom/val/budgets.yml
+++ b/config/locales/custom/val/budgets.yml
@@ -21,6 +21,10 @@ val:
         not_selected: Veure les propostes no seleccionades en la fase de revisió interna
         unselected_title: Propostes no seleccionades per a la votació final
         unselected: Veure les propostes no seleccionades per a la votació final
+        takecharged_title: Projectes assumits
+        takecharged: Veure els projectes assumits
+        included_next_year_budget_title: Veure els projectes previstos per a la seua inclusió en pressupostos del pròxim any
+        included_next_year_budget: Projectes previstos per a la seua inclusió en el pressupost del pròxim any
     phase:
       drafting: Fase d'sborrany (No visible per al públic)
       informing: Fase d'Informació i debats
@@ -68,6 +72,11 @@ val:
         unfeasible: Propostes d'inversió no viables
         not_selected: Propostes d'inversió no seleccionades a la fase de revisió interna
         unfeasible_text: "Les propostes presentades han de complir una sèrie de criteris (legalitat, concreció, no superar el límit del pressupost) per a ser declarades viables i arribar fins la fase de votació final. Totes les propostes que no compleixen aquests criteris són marcades com a inviables i publicades en la següent llista, juntament amb el seu informe d'inviabilitat."
+        takecharged: Propostes d'inversió assumides.
+        takecharged_text: Les propostes que ja s'hagen realitzat, s'estiguen realitzant en eixe moment o estiga prevista la seua realització, de manera fefaent, en l'exercici actual.
+        included_next_year_budget: Propuestas de inversión previstas para su inclusión en presupuestos del próximo año
+        included_next_year_budget_text: Les propostes que els servicis tenen previstes en les seues accions a desenrotllar durant l'any vinent.
+
         by_heading: "Propostes d'inversió amb àmbit: %{heading}"
         search_form:
           button: Cercar
@@ -91,6 +100,15 @@ val:
             other: "<strong>Has avalat %{count} propostes, pots continuar avalant propostes fins a arribar al màxim de %{max_supported_count}. Pots canviar els teus avals en qualsevol moment fins al %{phase_end_date}.</strong>"
           all_supports_html: "<strong>Ja no pots avalar més propostes d’inversió. Pots canviar els teus avals fins al %{phase_end_date}.</strong>"
           zero_supports: Encara no has avalat cap proposta d'inversió en este pressupost
+        filter: "Filtrant projectes"
+        filters:
+          not_unfeasible: "No inviables"
+          selected: "Seleccionats"
+          unfeasible: "Inviables"
+          unselected: "No seleccionats"
+          winners: "Guanyadors"
+          takecharged: "Assumits"
+          included_next_year_budget: "Prev. inclusió en presup. del próx. any"
         orders:
           random: aleatòries
           confidence_score: millor valorats
@@ -167,6 +185,8 @@ val:
       unfeasible_investment_proyects: Llista de projectes d'inversió no viables
       not_selected_investment_proyects: Llista de projectes d'inversió no seleccionats en la fase de revisió interna
       unselected_investment_proyects: Llista de tots els projectes d'inversió no seleccionats per a votació
+      takecharged_investment_proyects: Veure llista de projectes de gasto assumits
+      included_next_year_budget_investment_proyects: Veure llista de projectes de gasto previstos per a la seua inclusió en el pressupost del pròxim any
     executions:
       link: "Seguiments"
       page_title: "%{budget} - Fites"

--- a/config/locales/custom/val/mailers.yml
+++ b/config/locales/custom/val/mailers.yml
@@ -144,3 +144,6 @@ val:
       text_9: "També trobaràs aquesta nova acció de difusió recomanada…"
       text_10: "Segur que tens més recursos pendents d'usar!"
       dashboard_button: "Avant, descobreix-los!"
+    budget_change_active_phases:
+      success: "%{budget_name} ha cambiado de la fase '%{previous_phase}' a '%{next_phase}'"
+      error: Error al cambiar de fase

--- a/config/locales/custom/val/mailers.yml
+++ b/config/locales/custom/val/mailers.yml
@@ -71,6 +71,18 @@ val:
       hi: "Estimat/da usuari/a,"
       thanks: "Gràcies de nou per la teua participació."
       sincerely: "Atentament"
+    budget_investment_takecharge:
+      hi: "Estimat/da usuari/a"
+      explanation: 'El seu projecte no passa a la següent fase de suports perquè ha sigut assumit pel Generalitat.'
+      sincerely: "Atentament"
+      sorry: "Gràcies de nou per la teua participació."
+      subject: "Tu proyecto de gasto '%{code}' ha sigut assumit pel generalitat"
+    budget_investment_next_year_budget:
+      hi: "Estimat/da usuari/a"
+      explanation: 'El seu projecte no passa a la següent fase de suports perquè està prevista la seua inclusió en els pressupostos del pròxim any.'
+      sincerely: "Atentament"
+      sorry: "Gràcies de nou per la teua participació."
+      subject: "Tu proyecto de gasto '%{code}' està previst per a inclusió l'any vinent"
     evaluation_comment:
       subject: "Nou comentari d’avaluació"
       title: Nou comentari d’avaluació per a %{investment}

--- a/config/locales/custom/val/valuation.yml
+++ b/config/locales/custom/val/valuation.yml
@@ -49,6 +49,8 @@ val:
         unfeasible: Inviable
         not_selected: No seleccionada
         undefined: Sense definir
+        takecharge: Assumit
+        nextyearbudget: Prevista inclusió en pressupostos del pròxim any
         valuation_finished: Avaluació finalitzada
         duration: Plaç d'execució
         responsibles: Responsables
@@ -57,7 +59,11 @@ val:
       edit:
         dossier: Informe
         feasibility: Viabilitat
+        takecharge: "Assumit"
+        nextyearbudget: "Prevista inclusió en pressupostos del pròxim any"
         valuation_finished_alert: "Segur que vols marcar este informe com a finalitzat? Si ho fas, no podràs modificarlo més."
+        feasible_explanation_html_takecharge: Informe d'assumit <small>(en cas que el projecte siga ASSUMIT es mostrarà esta informació, dada pública)</small>
+        feasible_explanation_html_next_year_budget: Informe de selecció per a l'any vinent <small>(en cas que el projecte siga SELECCIONAT PER A L'any vinent es mostrarà esta informació, dada pública)</small>
         not_feasible_alert: "Un correu electrònic s'ha enviat a l'autor del projecte amb l'informe d'inviabilitat."
         not_selected_alert: "Un correu electrònic s'ha enviat a l'autor del projecte amb l'informe de no selecció."
         save: Guardar canvis

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -66,7 +66,7 @@ namespace :admin do
         patch :toggle_selection
         patch :toggle_winner
       end
-
+      patch :bulk_actions, on: :collection
       resources :audits, only: :show, controller: "budget_investment_audits"
       resources :milestones, controller: "budget_investment_milestones"
       resources :progress_bars, except: :show, controller: "budget_investment_progress_bars"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -62,7 +62,10 @@ namespace :admin do
     end
 
     resources :budget_investments, only: [:index, :show, :edit, :update] do
-      member { patch :toggle_selection }
+      member do
+        patch :toggle_selection
+        patch :toggle_winner
+      end
 
       resources :audits, only: :show, controller: "budget_investment_audits"
       resources :milestones, controller: "budget_investment_milestones"

--- a/config/routes/budget.rb
+++ b/config/routes/budget.rb
@@ -18,6 +18,7 @@ resources :budgets, only: [:show, :index] do
   resource :results, only: :show, controller: "budgets/results"
   resource :stats, only: :show, controller: "budgets/stats"
   resource :executions, only: :show, controller: "budgets/executions"
+  resource :status_executions, only: :show, controller: "budgets/status_executions"
 end
 
 resolve "Budget::Investment" do |investment, options|

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -39,6 +39,10 @@ every 1.day, at: "3:00 am", roles: [:cron] do
   rake "votes:reset_hot_score"
 end
 
+every 1.day, at: "00:00", roles: [:cron] do
+  runner "Budget.change_phase"
+end
+
 every :reboot do
   # Number of workers must be kept in sync with capistrano's delayed_job_workers
   command "cd #{@path} && RAILS_ENV=#{@environment} bin/delayed_job -m -n 2 restart"

--- a/db/migrate/20240730112312_add_new_explanation_fields_to_investments.rb
+++ b/db/migrate/20240730112312_add_new_explanation_fields_to_investments.rb
@@ -1,0 +1,8 @@
+class AddNewExplanationFieldsToInvestments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :budget_investments, :next_year_budget_explanation, :text
+    add_column :budget_investments, :next_year_budget_email_sent_at, :datetime
+    add_column :budget_investments, :takecharge_explanation, :text
+    add_column :budget_investments, :takecharge_email_sent_at, :datetime
+  end
+end

--- a/db/migrate/20240731125848_add_milestone_status_translations.rb
+++ b/db/migrate/20240731125848_add_milestone_status_translations.rb
@@ -1,0 +1,18 @@
+class AddMilestoneStatusTranslations < ActiveRecord::Migration[6.1]
+  def self.up
+    I18n.locale = :es
+    Milestone::Status.create_translation_table!(
+      {
+        name:        :string,
+        description: :text
+      },
+      {
+        migrate_data: true
+      }
+    )
+  end
+
+  def self.down
+    Milestone::Status.drop_translation_table!
+  end
+end

--- a/db/migrate/20240801082637_add_kind_to_milestone_status.rb
+++ b/db/migrate/20240801082637_add_kind_to_milestone_status.rb
@@ -1,0 +1,5 @@
+class AddKindToMilestoneStatus < ActiveRecord::Migration[6.1]
+  def change
+    add_column :milestone_statuses, :kind, :string
+  end
+end

--- a/db/migrate/20240807095311_add_status_executions_to_reports.rb
+++ b/db/migrate/20240807095311_add_status_executions_to_reports.rb
@@ -1,0 +1,6 @@
+class AddStatusExecutionsToReports < ActiveRecord::Migration[6.1]
+  def change
+    add_column :reports, :status_executions, :boolean
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_23_082325) do
+ActiveRecord::Schema.define(version: 2024_07_30_112312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -308,6 +308,10 @@ ActiveRecord::Schema.define(version: 2023_11_23_082325) do
     t.integer "original_heading_id"
     t.text "not_selected_explanation"
     t.datetime "not_selected_email_sent_at"
+    t.text "next_year_budget_explanation"
+    t.datetime "next_year_budget_email_sent_at"
+    t.text "takecharge_explanation"
+    t.datetime "takecharge_email_sent_at"
     t.index ["administrator_id"], name: "index_budget_investments_on_administrator_id"
     t.index ["author_id"], name: "index_budget_investments_on_author_id"
     t.index ["budget_id"], name: "index_budget_investments_on_budget_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_01_082637) do
+ActiveRecord::Schema.define(version: 2024_08_07_095311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1419,6 +1419,7 @@ ActiveRecord::Schema.define(version: 2024_08_01_082637) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "advanced_stats"
+    t.boolean "status_executions"
     t.index ["process_type", "process_id"], name: "index_reports_on_process_type_and_process_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_30_112312) do
+ActiveRecord::Schema.define(version: 2024_08_01_082637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -982,12 +982,24 @@ ActiveRecord::Schema.define(version: 2024_07_30_112312) do
     t.index ["proposal_id"], name: "index_map_locations_on_proposal_id"
   end
 
+  create_table "milestone_status_translations", force: :cascade do |t|
+    t.integer "milestone_status_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
+    t.text "description"
+    t.index ["locale"], name: "index_milestone_status_translations_on_locale"
+    t.index ["milestone_status_id"], name: "index_milestone_status_translations_on_milestone_status_id"
+  end
+
   create_table "milestone_statuses", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "hidden_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "kind"
     t.index ["hidden_at"], name: "index_milestone_statuses_on_hidden_at"
   end
 

--- a/lib/tasks/custom/milestone.rake
+++ b/lib/tasks/custom/milestone.rake
@@ -1,13 +1,13 @@
 namespace :milestone do
   desc "Create default milestone"
-  task create_milestone: :environment do
-    %i[val es].each do |locale|
-      I18n.locale = locale
-      %w[drafting processing execution executed].each do |state|
-        Milestone::Status.find_or_create_by(
-          name: I18n.t("budgets.milestone.statuses.#{state}"),
-          description: I18n.t("budgets.milestone.statuses.#{state}_description")
-        )
+  task create_status: :environment do
+    %w[drafting processing execution executed].each do |state|
+      status = Milestone::Status.find_or_create_by(kind: state)
+      %i[val es].each do |locale|
+        I18n.locale = locale
+        status.send(:"name_#{locale}=", I18n.t("budgets.milestone.statuses.#{state}"))
+        status.send(:"description_#{locale}=", I18n.t("budgets.milestone.statuses.#{state}_description"))
+        status.save!
       end
     end
   end

--- a/lib/tasks/custom/milestone.rake
+++ b/lib/tasks/custom/milestone.rake
@@ -1,0 +1,14 @@
+namespace :milestone do
+  desc "Create default milestone"
+  task create_milestone: :environment do
+    %i[val es].each do |locale|
+      I18n.locale = locale
+      %w[drafting processing execution executed].each do |state|
+        Milestone::Status.find_or_create_by(
+          name: I18n.t("budgets.milestone.statuses.#{state}"),
+          description: I18n.t("budgets.milestone.statuses.#{state}_description")
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## References

Issue 6810

## Objectives

Mejorar usabilidad de presupuestos participativos

## Visual Changes

- Modificar el código para que las fases se cambien automáticamente en base a la configuración detallada en el panel de administración. Actualmente hay que cambiar las fases a mano.
- Permitir realizar acciones en lote.
- Permitir que los administradores puedan marcar proyectos de gasto como ganadores desde el área de administración.
- Creación de listas personalizadas para los proyectos de gasto que queden en estados no contemplados por la plataforma, como pueden ser "asumidas", "previstas en el presupuesto del siguiente año", etc....
- Crear hitos por defecto para las fases de seguimiento (tipo etiquetas): redacción, tramitación, ejecución, ejecutado.
- Añadir una pestaña más en las vistas de la publicación de resultados donde se muestre el estado de ejecución de los proyectos. Esta vista se plantea siguiendo el ejemplo de la plataforma del Ayuntamiento de Valencia.
https://decidimvlc.valencia.es/budgets/6/results#more_information

