### PR TITLE
GESTIC-1077075 Mejoras 2025 - Permitir registro solamente de ciudadanos empadronados en la Comunidad Valenciana 

### DIFF
--- a/app/components/custom/account/verify_account_component.html.erb
+++ b/app/components/custom/account/verify_account_component.html.erb
@@ -16,14 +16,7 @@
           age_url = Verification::Residence.procedure_url(:age, link_locale)
           foreign_url = Verification::Residence.procedure_url(:foreign, link_locale)
 
-          if account.residence_requested_foreign? && account.residence_requested_age?
-            age_link = link_to t('account.show.residence_request_procedure'), age_url
-            foreign_link = link_to t('account.show.residence_request_procedure'), foreign_url
-            message = t('account.show.required_age_foreign_residence_verification_request', age_link: age_link, foreign_link: foreign_link, required_age: User.minimum_required_age)
-          elsif account.residence_requested_foreign?
-            link = link_to t('account.show.residence_request_procedure'), foreign_url
-            message = t('account.show.foreign_residence_verification_request', link: link, required_age: User.minimum_required_age)
-          elsif account.residence_requested_age?
+          if account.residence_requested_age?
             link = link_to t('account.show.residence_request_procedure'), age_url
             message = t('account.show.required_age_verification_request', link: link, required_age: User.minimum_required_age)
           end

--- a/app/controllers/custom/verification/residence_controller.rb
+++ b/app/controllers/custom/verification/residence_controller.rb
@@ -14,14 +14,7 @@ class Verification::ResidenceController
         age_url = Verification::Residence.procedure_url(:age, link_locale)
         foreign_url = Verification::Residence.procedure_url(:foreign, link_locale)
 
-        if current_user.residence_requested_foreign? && current_user.residence_requested_age?
-          age_link = helpers.link_to t("verification.residence.create.flash.procedure"), age_url
-          foreign_link = helpers.link_to t("verification.residence.create.flash.procedure"), foreign_url
-          notice = t("verification.residence.create.flash.required_age_foreign_residence_request_form", age_link: age_link, foreign_link: foreign_link)
-        elsif current_user.residence_requested_foreign?
-          link = helpers.link_to t("verification.residence.create.flash.procedure"), foreign_url
-          notice = t("verification.residence.create.flash.foreign_residence_request_form", link: link)
-        elsif current_user.residence_requested_age?
+        if current_user.residence_requested_age?
           link = helpers.link_to t("verification.residence.create.flash.procedure"), age_url
           notice = t("verification.residence.create.flash.required_age_request_form", link: link, required_age: User.minimum_required_age)
         end
@@ -44,6 +37,6 @@ class Verification::ResidenceController
     end
 
     def allowed_params
-      [:document_number, :document_type, :date_of_birth, :postal_code, :terms_of_service, :gender, :name, :first_surname, :last_surname, :foreign_residence]
+      [:document_number, :document_type, :date_of_birth, :postal_code, :terms_of_service, :gender, :name, :first_surname, :last_surname]
     end
 end

--- a/app/helpers/custom/users_helper.rb
+++ b/app/helpers/custom/users_helper.rb
@@ -1,8 +1,7 @@
 module Custom::UsersHelper
-  
+
   def special_verification_reason(user)
     text = []
-    text << t("admin.users.columns.residence_requested_reasons.foreign_residence") if user.residence_requested_foreign?
     text << t("admin.users.columns.residence_requested_reasons.older_than_soft_minimum_required_age", required_age: User.minimum_required_age) if user.residence_requested_age?
     text.join(", ")
   end

--- a/app/models/custom/signature.rb
+++ b/app/models/custom/signature.rb
@@ -2,7 +2,7 @@ require_dependency Rails.root.join("app", "models", "signature").to_s
 
 class Signature < ApplicationRecord
 
-  attr_accessor :gender, :name, :first_surname, :last_surname, :foreign_residence
+  attr_accessor :gender, :name, :first_surname, :last_surname
 
   def in_census?
     other_data = { date_of_birth: date_of_birth, postal_code: postal_code, name: name, first_surname: first_surname, last_surname: last_surname }

--- a/app/models/custom/user.rb
+++ b/app/models/custom/user.rb
@@ -41,10 +41,6 @@ class User
     age >= User.soft_minimum_required_age && age < User.minimum_required_age
   end
 
-  def residence_requested_foreign?
-    foreign_residence?
-  end
-
   def can_vote_budget_investment_for_this_budget?(budget_id)
     return false unless id # Esto no deberia pasar.
     return false unless budget_id # El budget_id es necesario.

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -19,14 +19,14 @@ class Verification::Residence
   }.freeze
 
   undef gender
-  attr_accessor :gender, :name, :first_surname, :last_surname, :foreign_residence
+  attr_accessor :gender, :name, :first_surname, :last_surname
 
   def save
     return false unless valid?
 
     user.take_votes_if_erased_document(document_number, document_type)
 
-    if !census_data.valid? && foreign_residence? || Age.in_years(date_of_birth).in?(User.soft_minimum_required_age...User.minimum_required_age)
+    if Age.in_years(date_of_birth).in?(User.soft_minimum_required_age...User.minimum_required_age)
       residence_requested_at = Time.current
     else
       residence_verified_at = Time.current
@@ -40,7 +40,6 @@ class Verification::Residence
                 gender:                 gender,
                 residence_verified_at:  residence_verified_at,
                 residence_requested_at: residence_requested_at,
-                foreign_residence:      foreign_residence,
                 services_results:       (census_data.data if census_data.is_a?(CensusApi::Response)))
   end
 
@@ -84,7 +83,6 @@ class Verification::Residence
       document_type:     document_type,
       date_of_birth:     date_of_birth,
       postal_code:       postal_code,
-      foreign_residence: foreign_residence,
       services_results:  (census_data.data if census_data.respond_to?(:data)))
   end
 
@@ -99,15 +97,6 @@ class Verification::Residence
       @census_data ||= CensusCaller.new.call(document_type, document_number, other_data)
     end
 
-    def residency_valid?
-      # If age service returns ok, foreign residence is checked and residence service returns no residence error, we return true
-      return true if !census_data.valid? &&
-                     foreign_residence? &&
-                     census_data.respond_to?(:error) &&
-                     census_data.error == "No residente"
-
-      census_data.valid?
-    end
 
     def postal_code_valid?
       census_data.postal_code.to_s == postal_code
@@ -129,7 +118,4 @@ class Verification::Residence
       end
     end
 
-    def foreign_residence?
-      foreign_residence == "1"
-    end
 end

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -51,6 +51,7 @@ class Verification::Residence
 
   def local_residence
     return if errors.any? # return to form with validation messages
+
     unless residency_valid?
       if census_data.respond_to?(:error) && census_data.error =~ /^Servicio no disponible/
         errors.add(:base, I18n.t("verification.residence.new.error_service_not_available"))
@@ -58,8 +59,11 @@ class Verification::Residence
       end
 
       unless census_data.datos_vivienda?
-        if census_data.datos_vivienda_error == :error_0231
+        case census_data.datos_vivienda_error
+        when :error_0231
           errors.add(:postal_code, I18n.t("verification.residence.new.invalid_postal_code"))
+        when :outside_cv
+          errors.add(:base, I18n.t("verification.residence.new.only_residents_allowed"))
         end
         errors.add(:local_residence, false)
       end
@@ -97,7 +101,6 @@ class Verification::Residence
       @census_data ||= CensusCaller.new.call(document_type, document_number, other_data)
     end
 
-
     def postal_code_valid?
       census_data.postal_code.to_s == postal_code
     end
@@ -117,5 +120,4 @@ class Verification::Residence
         end
       end
     end
-
 end

--- a/app/views/custom/verification/residence/new.html.erb
+++ b/app/views/custom/verification/residence/new.html.erb
@@ -70,16 +70,6 @@
           hint: raw(t("verification.residence.new.postal_code_note", link: link)) %>
         </div>
 
-        <div class="small-12">
-            <%= f.check_box :foreign_residence,
-          title: t("verification.residence.new.foreign_residence"),
-          label: t("verification.residence.new.foreign_residence",
-                   terms_url: link_to(t("verification.residence.new.terms"), page_path("census_terms"),
-                                      title: t("shared.target_blank"),
-                                      target: "_blank")
-                  ) %>
-        </div>
-
         <div class="small-12 medium-5 clear">
             <%= f.select :gender, genders, prompt: "", label: t("verification.residence.new.gender_label") %>
         </div>

--- a/config/locales/custom/en/verification.yml
+++ b/config/locales/custom/en/verification.yml
@@ -5,3 +5,4 @@ en:
         invalid_postal_code: Postal code does not match
         error_verifying_census_1: The Census was unable to verify your information
         error_verifying_census_2: Please confirm that your census details are correct by calling to City Council or visit one Citizen Support Office.
+        only_residents_allowed: Only residents of the Valencian Community can register.

--- a/config/locales/custom/es/verification.yml
+++ b/config/locales/custom/es/verification.yml
@@ -65,6 +65,7 @@ es:
         invalid_date_of_birth: La fecha de nacimiento no coincide
         invalid_postal_code: El código postal no coincide
         invalid_document_number: El número de documento es incorrecto
+        only_residents_allowed: Solo pueden registrarse personas residentes en la Comunitat Valenciana.
         gender_label: Género
         not_verified: No verificada
         postal_code: Código postal

--- a/config/locales/custom/es/verification.yml
+++ b/config/locales/custom/es/verification.yml
@@ -47,7 +47,7 @@ es:
           procedure: procedimiento
           required_age_request_form: Se han guardado tus datos para verificar tu residencia, pero al ser menor de %{required_age} años debes seguir este %{link}
           foreign_residence_request_form: El Padrón no pudo verificar tu información. Por favor, confirma que tus datos de empadronamiento sean correctos informándote en tu municipio de empadronamiento. Si eres valenciano, pero eres residente en el extranjero o fuera de la Comunitat Valenciana, y no estás empadronado, debes seguir este %{link}.
-          required_age_foreign_residence_request_form: "El Padrón no pudo verificar tu información. Por favor, confirma que tus datos de empadronamiento sean correctos informándote en tu municipio de empadronamiento. Si eres valenciano, pero eres residente en el extranjero o fuera de la Comunitat, y no estás empadronado, debes seguir este %{foreign_link}.
+          required_age_foreign_residence_request_form: "El Padrón no pudo verificar tu información. Por favor, confirma que tus datos de empadronamiento sean correctos informándote en tu municipio de empadronamiento.
           Por otro lado, como eres menor de %{required_age} años, debes también seguir este %{age_link} para completar la verificación."
       new:
         accept_terms_text: Declaro que la información transmitida es exacta y que acepto %{terms_url}
@@ -78,7 +78,7 @@ es:
         error_service_not_available: No se pudo conectar con el servicio de verificación. Por favor, inténtalo más tarde.
         foreign_residence: Resido fuera de la Comunitat Valenciana, pero soy valenciano
         form_errors: evitaron verificar tu residencia
-        postal_code_note: Para verificar tus datos debes estar empadronado/a en la Comunitat Valenciana. Si eres valenciano, pero eres residente en el extranjero o fuera de la Comunitat, puedes indicarlo a continuación y seguir el siguiente %{link}. En ese caso, indica aquí el último código postal donde viviste.
+        postal_code_note: Para verificar tus datos debes estar empadronado/a en la Comunitat Valenciana. Actualmente solo se permite el registro de personas empadronadas en la Comunitat Valenciana.
         procedure: procedimiento
         terms: los términos de acceso a los servicios de verificación de edad y residencia
         title: Verificar residencia

--- a/config/locales/custom/val/verification.yml
+++ b/config/locales/custom/val/verification.yml
@@ -47,7 +47,7 @@ val:
           procedure: procediment
           required_age_request_form: S'han guardat les teues dades per a verificar la teua residència, però com eres menor de %{required_age} anys has de seguir aquest %{link}
           foreign_residence_request_form: El Padró no ha pogut verificar la teua informació. Per favor, confirma que les teues dades d'empadronament siguen correctes informant-te en el teu municipi d'empadronament. Si eres valencià, però eres resident a l'estranger o fora de la Comunitat, i no estàs empadronat, has de seguir aquest %{link}
-          required_age_foreign_residence_request_form: "El Padró no ha pogut verificar la teua informació. Per favor, confirma que les teues dades d'empadronament siguen correctes informant-te en el teu municipi d'empadronament. Si eres valencià, però eres resident a l'estranger o fora de la Comunitat, i no estàs empadronat, has de seguir aquest %{foreign_link}.
+          required_age_foreign_residence_request_form: "El Padró no ha pogut verificar la teua informació. Per favor, confirma que les teues dades d'empadronament siguen correctes informant-te en el teu municipi d'empadronament.
           D'altra banda, com eres menor de %{required_age} anys, també has de seguir aquest %{age_link} per a completar la verificació."
       new:
         accept_terms_text: Declare que la informació transmesa és exacta i que accepte els %{terms_url}
@@ -78,7 +78,7 @@ val:
         error_service_not_available: "No es va poder connectar amb el servei de verificació. Per favor, intente-ho més tard."
         foreign_residence: Residisc fora de la Comunitat Valenciana, però soc valencià
         form_errors: evitaren verificar la teua residència
-        postal_code_note: Per a verificar les teues dades has d’estar empadronat/ada a la Comunitat Valenciana. Si eres valencià, però eres resident a l'estranger o fora de la Comunitat, pots indicar-ho a continuació i seguir el següent %{link}. En aquest cas, indica l’últim codi postal on vas viure.
+        postal_code_note: Per a verificar les teues dades has d’estar empadronat/ada a la Comunitat Valenciana. Actualment només es permet el registre de persones empadronades en la Comunitat Valenciana.
         procedure: procediment
         terms: termes d’accés als serveis de verificació d’edat i residència
         title: Verificar residència

--- a/config/locales/custom/val/verification.yml
+++ b/config/locales/custom/val/verification.yml
@@ -65,6 +65,7 @@ val:
         invalid_date_of_birth: La data de naixement no coincideix
         invalid_postal_code: El codi postal no coincideix
         invalid_document_number: El número de document és incorrecte
+        only_residents_allowed: Només es poden registrar les persones residents a la Comunitat Valenciana.
         gender_label: Gènere
         postal_code: Codi postal
         name: Nom

--- a/lib/custom/census_api.rb
+++ b/lib/custom/census_api.rb
@@ -19,6 +19,7 @@ class CensusApi
         unless data[:datos_vivienda]["error"]
           return :error_0233 if data[:datos_vivienda]["estado"] =~ /^0233/ #"Titular no Identificado o Ámbito Territorial de Residencia Incorrecto"
           return :error_4 if data[:datos_vivienda]["estado"] =~ /^4/ #"Ámbito Territorial Residencia Incorrecto"
+          return :outside_cv if data[:datos_vivienda]["estado"] == "6" #"NO POSEE PERMISOS PARA REALIZAR LA CONSULTA"
         else
           return :error_0231 if data[:datos_vivienda]["error"] =~ /^0231/ #Se ha recibido una petición en la que la validación del NIFTitular es incorrecta
         end
@@ -40,14 +41,13 @@ class CensusApi
     end
 
     def valid?
-      return false if data =~ /^ERROR/
+      return false if data.is_a?(String) && data =~ /^ERROR/
 
       datos_vivienda? && datos_habitante?
     end
 
     def error
-      return data if data =~ /^ERROR/
-
+      return data if data.is_a?(String) && data =~ /^ERROR/
       error = !datos_vivienda? && data[:datos_vivienda]["error"] ||
       !datos_habitante? && data[:datos_habitante]["error"]
 
@@ -65,11 +65,11 @@ class CensusApi
     end
 
     def postal_code
-      data[:datos_originales][:postal_code] # Devolvemos el dato entrado porque el servicio sólo comprueba residencia, no devuelve datos
+      data[:datos_originales][:postal_code] # Devolvemos el dato entrado porque el servicio sólo comprueba residencia, no devuelve datos # rubocop:disable Layout/LineLength
     end
 
     def district_code
-      data[:datos_originales][:postal_code][0..1] # Devolvemos el dato entrado porque el servicio sólo comprueba residencia, no devuelve datos
+      data[:datos_originales][:postal_code][0..1] # Devolvemos el dato entrado porque el servicio sólo comprueba residencia, no devuelve datos # rubocop:disable Layout/LineLength
     end
 
     def gender
@@ -180,6 +180,7 @@ class CensusApi
         stubbed_valid_response
       else
         stubbed_invalid_response
+        # stubbed_invalid_outcome
       end
     end
 
@@ -277,6 +278,33 @@ class CensusApi
           # "estado" => "4",
           # "estado" => "0233",
           # "literal" => "Ãmbito Territorial de Residencia Incorrecto"
+        },
+        datos_originales: {
+          postal_code: "46001",
+          name: "NAME",
+          first_surname: "FIRST SURNAME",
+          last_surname: "LAST SURNAME",
+          date_of_birth: 25.years.ago.to_date
+        }
+      }
+    end
+
+    def stubbed_invalid_outcome
+      {
+        datos_habitante: {
+          "resultado" => true,
+          "error" => false,
+          "cod_estado" => "00",
+          "literal_error" => "INFORMACION CORRECTA",
+          "nacionalidad" => "ESPAÑA-ESP",
+          "sexo" => "H",
+          "fecha_nacimiento" => "20030518"
+        },
+        datos_vivienda: {
+          "resultado" => false,
+          "error" => false,
+          "estado" => "6",
+          "literal" => "NO POSEE PERMISOS PARA REALIZAR LA CONSULTA"
         },
         datos_originales: {
           postal_code: "46001",

--- a/spec/models/custom/verification/residence_spec.rb
+++ b/spec/models/custom/verification/residence_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Verification::Residence, consul: true do
+describe Verification::Residence do
   let!(:geozone) { create(:geozone, census_code: "46") }
   let(:residence) { build(:verification_residence,
                     name: Faker::Name.name,
@@ -252,7 +252,7 @@ describe Verification::Residence, consul: true do
   end
 
   describe "tries" do
-    it "increases tries after a call to the Census", consul: true do
+    it "increases tries after a call to the Census" do
       residence.postal_code = "12001"
       residence.valid?
       expect(residence.user.lock.tries).to eq(1)
@@ -266,7 +266,7 @@ describe Verification::Residence, consul: true do
   end
 
   describe "Failed census call" do
-    it "stores failed census API calls", consul: true do
+    it "stores failed census API calls" do
       residence = build(:verification_residence,
                         :invalid,
                         name: Faker::Name.name,
@@ -274,16 +274,16 @@ describe Verification::Residence, consul: true do
                         last_surname: Faker::Name.last_name,
                         gender: "male",
                         postal_code: "46100",
-                        document_number: "12345678Z")
+                        document_number: "12345678W")
       residence.save
 
       expect(FailedCensusCall.count).to eq(1)
       expect(FailedCensusCall.first).to have_attributes(
         user_id:         residence.user.id,
-        document_number: "12345678Z",
+        document_number: "12345678W",
         document_type:   "1",
         date_of_birth:   Date.new(1980, 12, 31),
-        postal_code:     "28001"
+        postal_code:     "46100"
       )
     end
   end

--- a/spec/models/custom/verification/residence_spec.rb
+++ b/spec/models/custom/verification/residence_spec.rb
@@ -232,6 +232,26 @@ describe Verification::Residence do
       residence = Verification::Residence.new(document_number: " 12.345.678 - B")
       expect(residence.document_number).to eq("12345678B")
     end
+
+    describe "INE error estado 6" do
+      it "shows error if INE says no permission to verify residence (estado 6)" do
+        outcome = CensusApi.new.send(:stubbed_invalid_outcome)
+
+        allow_any_instance_of(CensusApi).to receive(:stubbed_response).and_return(outcome)
+
+        residence = build(:verification_residence,
+                          name: "NAME",
+                          first_surname: "FIRST SURNAME",
+                          last_surname: "LAST SURNAME",
+                          gender: "male",
+                          postal_code: "46001",
+                          document_number: "12345678X")
+
+        residence.valid?
+
+        expect(residence.errors[:base]).to include("Only residents of the Valencian Community can register.")
+      end
+    end
   end
 
   describe "save" do


### PR DESCRIPTION
## References

> issue/7975

## Objectives

- Eliminar del formulario de registro la casilla donde pueden marcar/indicar que residen fuera de la CV  y todas sus validaciones

- Añadir en la plataforma GVA Participa, en el formulario de registro, una nota informativa para indicar que solo se permite el registro de personas empadronadas en la CV.

- Analizar e implementar la posibilidad a partir de la respuesta de error del INE mostrar un mensaje al ciudadano indicando que solo es posible el registro para residentes en la CV.

- Analizar en la plataforma GVA Participa, si hay alguna mención al proceso de registro de residentes fuera de la CV, para eliminarlo.

