### PR TITLE
feat: Add results filter to Legislation Processes

### DIFF
--- a/app/models/custom/bulletin.rb
+++ b/app/models/custom/bulletin.rb
@@ -3,7 +3,8 @@ class Bulletin < ApplicationRecord
                 debate
                 legislation_process_preview_phase
                 legislation_process_public_phase
-                legislation_process_past].freeze
+                legislation_process_past
+                legislation_process_results].freeze
 
   MAX_DISPLAY_DATES = 5
 

--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -11,7 +11,7 @@ class Legislation::Process
   has_many :legislators, through: :process_legislators
 
   def self.processes_filters
-    %w[preview_phase public_phase past relevance]
+    %w[preview_phase public_phase past relevance results]
   end
 
   scope :preview_phase, -> {
@@ -21,6 +21,8 @@ class Legislation::Process
   scope :public_phase, -> { where("allegations_phase_enabled = true and (allegations_start_date <= :date and allegations_end_date >= :date)", date: Date.current) } # rubocop:disable Layout/LineLength
 
   scope :last_week, -> { where("created_at >= ?", 7.days.ago) }
+
+  scope :results, -> { where(result_publication_enabled: true).where.not(result_publication_date: nil) }
 
   def searchable_values
     {

--- a/app/views/custom/admin/bulletin_templates/_legislation_process_results.html.erb
+++ b/app/views/custom/admin/bulletin_templates/_legislation_process_results.html.erb
@@ -1,0 +1,11 @@
+<table cellpadding="0" cellspacing="0" border="0" style="background: #fff; margin: 0 auto; max-width: 700px; width:100%;">
+  <tbody>
+    <tr>
+      <td>
+        <h2 style="color: #222; font-size: 2rem;"><%= t("admin.bulletin_templates.legislation_processes_results.title") %></h2>
+      </td>
+    </tr>
+    <%- @processes = Legislation::Process.results.last(5) %>
+    <%= render partial: "process", collection: @processes %>
+  </tbody>
+</table>

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -503,6 +503,7 @@ es:
           legislation_process_preview_phase: Elaboración normativa - Consulta previa
           legislation_process_public_phase: Elaboración normativa - Audiencia ciudadana
           legislation_process_past: Elaboración normativa - Finalizados
+          legislation_process_results: Elaboración normativa - Resultados de la consulta
         sent_at_dates: Fechas de envío
         last_send_date: Último envío
       newsletter:

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -959,6 +959,8 @@ es:
         title: Novedades de elaboración normativa (audiencia ciudadana)
       legislation_processes_past:
         title: Novedades de elaboración normativa (finalizados)
+      legislation_processes_results:
+        title: Novedades de elaboración normativa (resultados de la consulta)
     bulletins:
       create_success: Boletín creado correctamente
       update_success: Boletín actualizado correctamente

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -62,6 +62,7 @@ es:
           preview_phase: Consulta previa
           public_phase: Audiencia ciudadana
           relevance: Más relevantes
+          results: Resultados de la consulta
         no_open_processes: No hay procesos activos
         no_past_processes: No hay procesos terminados
         no_preview_phase_processes: No hay procesos

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -447,6 +447,7 @@ val:
           legislation_process_preview_phase: Elaboració normativa - Consulta prèvia
           legislation_process_public_phase: Elaboració normativa - Audiència ciutadana
           legislation_process_past: Elaboració normativa - Finalitzats
+          legislation_process_results: Elaboració normativa - Resultats de la consulta
         sent_at_dates: Dates d'enviament
         last_send_date: Últim enviament
       newsletter:

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -696,6 +696,8 @@ val:
         title: Novetats d'elaboració normativa (audiència ciutadana)
       legislation_processes_past:
         title: Novetats d'elaboració normativa (finalitzats)
+      legislation_processes_results:
+        title: Novetats d'elaboració normativa (resultats de la consulta)
     bulletins:
       create_success: Butlletí creat correctament
       update_success: Butlletí actualitzat correctament

--- a/config/locales/custom/val/legislation.yml
+++ b/config/locales/custom/val/legislation.yml
@@ -62,6 +62,7 @@ val:
           preview_phase: Consulta prèvia
           public_phase: Audiència ciutadana
           relevance: Més rellevants
+          results: Resultats de la consulta
         no_open_processes: No hi ha processos actius
         no_past_processes: No hi ha processos finalitzats
         no_preview_phase_processes: No hi ha processos


### PR DESCRIPTION
## Objectives

> Add results filter to the legislation processes and show which have result_publication_enabled and a result_publication_date.

## Visual Changes

<img width="1832" height="1319" alt="image" src="https://github.com/user-attachments/assets/0509fffe-c298-4abf-92b4-91c5b2044625" />
