### PR TITLE
feat: Sort legislation processes by the corresponding date

### DIFF
--- a/app/controllers/custom/legislation/processes_controller.rb
+++ b/app/controllers/custom/legislation/processes_controller.rb
@@ -22,7 +22,7 @@ class Legislation::ProcessesController
     end
 
     @processes = advance_search_term_present? ? @processes.filter_by(@advanced_search_terms) : @processes
-    @processes = @processes.page(params[:page]).order(start_date: :desc)
+    @processes = @processes.page(params[:page]).order(order_by_phase)
     @tag_cloud = tag_cloud
   end
 
@@ -50,5 +50,16 @@ class Legislation::ProcessesController
       if (params[:search].present? || advance_search_present?) && params[:filter].blank?
         params[:filter] = "relevance"
       end
+    end
+
+    def order_by_phase
+      phase_dates = {
+        draft_phase: :draft_start_date,
+        preview_phase: :debate_start_date,
+        proposals_phase: :proposals_phase_start_date,
+        public_phase: :allegations_start_date,
+        results: :result_publication_date
+      }
+      { phase_dates[@current_filter.to_sym] || :start_date => :desc }
     end
 end

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     result_publication_enabled { true }
     published { true }
 
-    user { create(:legislator).user} # CUSTOM
+    user { create(:legislator).user } # CUSTOM
 
     trait :past do
       start_date { Date.current - 12.days }

--- a/spec/system/custom/legislation/processes_spec.rb
+++ b/spec/system/custom/legislation/processes_spec.rb
@@ -68,15 +68,34 @@ describe Legislation::Process do
       end
     end
 
-    scenario "Processes are sorted by descending start date" do
-      create(:legislation_process, title: "Process 1", start_date: 3.days.ago)
-      create(:legislation_process, title: "Process 2", start_date: 2.days.ago)
-      create(:legislation_process, title: "Process 3", start_date: Date.yesterday)
+    scenario "Processes are sorted by phase dates" do
+      # Preview phase
+      create(:legislation_process, title: "Preview 1", debate_start_date: 3.days.ago)
+      create(:legislation_process, title: "Preview 2", debate_start_date: Date.yesterday)
 
-      visit legislation_processes_path
+      visit legislation_processes_path(filter: "preview_phase")
+      expect("Preview 2").to appear_before("Preview 1")
 
-      expect("Process 3").to appear_before("Process 2")
-      expect("Process 2").to appear_before("Process 1")
+      # Public phase
+      create(:legislation_process, title: "Public 1", allegations_start_date: 3.days.ago)
+      create(:legislation_process, title: "Public 2", allegations_start_date: Date.yesterday)
+
+      visit legislation_processes_path(filter: "public_phase")
+      expect("Public 2").to appear_before("Public 1")
+
+      # Past
+      create(:legislation_process, title: "Past 1", start_date: 3.days.ago, end_date: Date.yesterday)
+      create(:legislation_process, title: "Past 2", start_date: Date.yesterday, end_date: Date.yesterday)
+
+      visit legislation_processes_path(filter: "past")
+      expect("Past 2").to appear_before("Past 1")
+
+      # Results phase
+      create(:legislation_process, title: "Result 1", result_publication_date: 3.days.ago)
+      create(:legislation_process, title: "Result 2", result_publication_date: Date.yesterday)
+
+      visit legislation_processes_path(filter: "results")
+      expect("Result 2").to appear_before("Result 1")
     end
 
     scenario "Participation phases are displayed only if there is a phase enabled" do


### PR DESCRIPTION
## Objectives

> Sort legislation processes by the corresponding date, depending on the selected filter