### PR TITLE
Issue/8412 Add councils, filters and update legislarion processes texts (backend)

### DIFF
--- a/app/assets/stylesheets/custom/legislation_process_form.scss
+++ b/app/assets/stylesheets/custom/legislation_process_form.scss
@@ -1,0 +1,7 @@
+.legislation-process-form {
+  fieldset.without_border_bottom {
+    &::after {
+      border-bottom: none;
+    }
+  }
+}

--- a/app/components/custom/admin/legislation/processes/form_component.html.erb
+++ b/app/components/custom/admin/legislation/processes/form_component.html.erb
@@ -1,0 +1,203 @@
+<%= render "shared/globalize_locales", resource: process %>
+
+<%= translatable_form_for [:admin, process], html: { class: "legislation-process-form" } do |f| %>
+
+  <%= render "shared/errors", resource: process %>
+
+  <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.draft_phase") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.draft_phase_description") %></span>
+    </legend>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :draft_start_date, id: "draft_start_date" %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :draft_end_date, id: "draft_end_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :draft_phase_enabled, checked: process.draft_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.process") %>
+    </legend>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :start_date, id: "start_date" %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :end_date, id: "end_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :published, checked: process.published?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.debate_phase") %>
+    </legend>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :debate_start_date, id: "debate_start_date" %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :debate_end_date, id: "debate_end_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :debate_phase_enabled, checked: process.debate_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.proposals_phase") %>
+    </legend>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :proposals_phase_start_date, id: "proposals_phase_start_date" %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :proposals_phase_end_date, id: "proposals_phase_end_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :proposals_phase_enabled, checked: process.proposals_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.allegations_phase") %>
+    </legend>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :allegations_start_date, id: "allegations_start_date" %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <%= f.date_field :allegations_end_date, id: "allegations_end_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :allegations_phase_enabled, checked: process.allegations_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <div class="small-12 medium-3 column end">
+      <%= f.date_field :draft_publication_date, id: "draft_publication_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :draft_publication_enabled, checked: process.draft_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <div class="small-12 medium-3 column end">
+      <%= f.date_field :result_publication_date, id: "result_publication_date" %>
+    </div>
+    <div class="small-12 medium-2 column margin-top">
+      <%= f.check_box :result_publication_enabled, checked: process.result_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <div class="small-12 medium-6 margin-bottom column end">
+      <%- if @councils.present? %>
+        <%= f.select :council_id,
+              @councils.map { |c| [c.title, c.id] },
+              { include_blank: @councils.any? ? "" : t("admin.councils.form.no_councils_defined") },
+              { disabled: @councils.blank? } %>
+      <% end %>
+      <% if helpers.current_ability.can? :create, Legislation::Council %>
+        <%= link_to t("admin.legislation.processes.form.admin_councils"),
+                    admin_legislation_councils_path %>
+      <% end %>
+    </div>
+  </fieldset>
+
+  <div class="row">
+    <div class="small-12 column">
+      <%= render Documents::NestedComponent.new(f) %>
+    </div>
+
+    <div class="small-12 column">
+      <%= render Images::NestedComponent.new(f) %>
+    </div>
+
+    <div class="small-12 column">
+      <h3><%= t("admin.legislation.processes.form.banner_title") %></h3>
+    </div>
+
+    <div class="small-6 large-3 column background-color-inputs">
+      <%= f.label :background_color, nil, for: "background_color_input", id: "background_color_label" %>
+      <p class="help-text"><%= t("admin.shared.color_help") %></p>
+      <div class="row collapse">
+        <div class="small-12 medium-6 column">
+          <%= f.text_field :background_color, label: false, type: :color, "aria-labelledby": "background_color_label" %>
+        </div>
+        <div class="small-12 medium-6 column">
+          <%= f.text_field :background_color, label: false, id: "background_color_input" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="small-6 large-3 column end font-color-inputs">
+      <%= f.label :font_color, nil, for: "font_color_input", id: "font_color_label" %>
+      <p class="help-text"><%= t("admin.shared.color_help") %></p>
+      <div class="row collapse">
+        <div class="small-12 medium-6 column">
+          <%= f.text_field :font_color, label: false, type: :color, "aria-labelledby": "font_color_label" %>
+        </div>
+        <div class="small-12 medium-6 column">
+          <%= f.text_field :font_color, label: false, id: "font_color_input" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 medium-9 column">
+        <%= translations_form.text_field :title %>
+      </div>
+
+      <div class="small-12 medium-9 column">
+        <%= translations_form.text_area :summary,
+                                        rows: 2,
+                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+      </div>
+
+      <div class="small-12 medium-9 column">
+        <%= translations_form.text_area :description,
+                                        rows: 5,
+                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+      </div>
+
+      <div class="small-12 medium-9 column end">
+        <%= translations_form.text_area :additional_info,
+                                        rows: 10,
+                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <div class="small-12 column">
+      <%= render SDG::RelatedListSelectorComponent.new(f) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-3 column clear end">
+      <%= f.submit(class: "button success expanded", value: t("admin.legislation.processes.#{admin_submit_action(process)}.submit_button")) %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/custom/admin/legislation/processes/form_component.html.erb
+++ b/app/components/custom/admin/legislation/processes/form_component.html.erb
@@ -25,6 +25,7 @@
   <fieldset>
     <legend class="small-12 medium-4 column">
       <%= t("admin.legislation.processes.form.process") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.process_description") %></span>
     </legend>
 
     <div class="small-12 medium-3 column">
@@ -39,9 +40,17 @@
     </div>
   </fieldset>
 
-  <fieldset>
+  <fieldset class="without_border_bottom">
     <legend class="small-12 medium-4 column">
-      <%= t("admin.legislation.processes.form.debate_phase") %>
+      <%= t("admin.legislation.processes.form.prior_consultation_phase") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.prior_consultation_phase_description") %></span>
+    </legend>
+  </fieldset>
+
+  <fieldset class="without_border_bottom">
+    <legend class="small-12 medium-4 column">
+      > <%= t("admin.legislation.processes.form.debate") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.debate_description") %></span>
     </legend>
 
     <div class="small-12 medium-3 column">
@@ -51,14 +60,17 @@
     <div class="small-12 medium-3 column">
       <%= f.date_field :debate_end_date, id: "debate_end_date" %>
     </div>
+
     <div class="small-12 medium-2 column margin-top">
       <%= f.check_box :debate_phase_enabled, checked: process.debate_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
     </div>
   </fieldset>
 
   <fieldset>
+
     <legend class="small-12 medium-4 column">
-      <%= t("admin.legislation.processes.form.proposals_phase") %>
+      > <%= t("admin.legislation.processes.form.proposals") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.proposals_description") %></span>
     </legend>
 
     <div class="small-12 medium-3 column">
@@ -73,9 +85,17 @@
     </div>
   </fieldset>
 
-  <fieldset>
+  <fieldset class="without_border_bottom">
     <legend class="small-12 medium-4 column">
       <%= t("admin.legislation.processes.form.allegations_phase") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.allegations_phase_description") %></span>
+    </legend>
+  </fieldset>
+
+  <fieldset>
+    <legend class="small-12 medium-4 column">
+      > <%= t("admin.legislation.processes.form.draft_contributions") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.draft_contributions_description") %></span>
     </legend>
 
     <div class="small-12 medium-3 column">
@@ -91,6 +111,11 @@
   </fieldset>
 
   <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.draft_publication") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.draft_publication_description") %></span>
+    </legend>
+
     <div class="small-12 medium-3 column end">
       <%= f.date_field :draft_publication_date, id: "draft_publication_date" %>
     </div>
@@ -100,6 +125,11 @@
   </fieldset>
 
   <fieldset>
+    <legend class="small-12 medium-4 column">
+      <%= t("admin.legislation.processes.form.final_result_publication") %>
+      <span class="help-text"><%= t("admin.legislation.processes.form.final_result_publication_description") %></span>
+    </legend>
+
     <div class="small-12 medium-3 column end">
       <%= f.date_field :result_publication_date, id: "result_publication_date" %>
     </div>

--- a/app/components/custom/admin/legislation/processes/form_component.rb
+++ b/app/components/custom/admin/legislation/processes/form_component.rb
@@ -1,0 +1,16 @@
+class Admin::Legislation::Processes::FormComponent < ApplicationComponent; end
+
+load Rails.root.join("app", "components", "admin", "legislation", "processes", "form_component.rb")
+
+class Admin::Legislation::Processes::FormComponent
+  include TranslatableFormHelper
+  include GlobalizeHelper
+
+  attr_reader :process, :councils
+  use_helpers :admin_submit_action
+
+  def initialize(process, councils: [])
+    @process = process
+    @councils = councils
+  end
+end

--- a/app/components/custom/admin/menu_component.rb
+++ b/app/components/custom/admin/menu_component.rb
@@ -9,7 +9,7 @@ class Admin::MenuComponent
         (debates_link if feature?(:debates)),
         comments_link,
         (polls_link if feature?(:polls)),
-        (legislation_link if feature?(:legislation)),
+        (legislation_links if feature?(:legislation)),
         (budgets_link if feature?(:budgets)),
         booths_links,
         (signature_sheets_link if feature?(:signature_sheets)),
@@ -33,6 +33,10 @@ class Admin::MenuComponent
       controller_name == "alert_messages" && params[:alert_message_id].present?
     end
 
+    def legislation?
+      [:councils, :processes].include?(controller_name.to_sym) || controller_name.start_with?("legislation::")
+    end
+
     def messages_sections
       %w[bulletins newsletters emails_download admin_notifications system_emails]
     end
@@ -43,6 +47,34 @@ class Admin::MenuComponent
         admin_key_systems_path,
         controller_name == "key_systems",
         class: "key-systems-link"
+      ]
+    end
+
+    def legislation_links
+      section(t("admin.menu.legislation"), active: legislation?, class: "legislation-link") do
+        link_list(
+          legislation_link,
+          councils_link,
+          id: "legislation_menu"
+        )
+      end
+    end
+
+    def legislation_link
+      [
+        t("admin.menu.legislation"),
+        admin_legislation_processes_path,
+        legislation? && controller_name != "councils",
+        class: "legislation-link"
+      ]
+    end
+
+    def councils_link
+      [
+        t("admin.menu.legislation_councils"),
+        admin_legislation_councils_path,
+        controller_name == "councils",
+        class: "legislation-councils-link"
       ]
     end
 

--- a/app/components/custom/shared/advanced_search_component.html.erb
+++ b/app/components/custom/shared/advanced_search_component.html.erb
@@ -68,6 +68,14 @@
       </div>
     <% end %>
 
+    <% if processes? %>
+      <div class="filter">
+        <label for="advanced_search_council"><%= t("shared.advanced_search.council") %></label>
+        <%= select_tag("advanced_search[council]", council_options,
+                      include_blank: t("shared.advanced_search.council_blank")) %>
+      </div>
+    <% end %>
+
     <div class="submit">
       <%= submit_tag t("shared.advanced_search.search"), class: "button expanded" %>
     </div>

--- a/app/components/custom/shared/advanced_search_component.rb
+++ b/app/components/custom/shared/advanced_search_component.rb
@@ -11,6 +11,10 @@ class Shared::AdvancedSearchComponent
     controller_path == "proposals"
   end
 
+  def processes?
+    controller_path == "legislation/processes"
+  end
+
   def categories_search_options
     options_for_select(Tag.category.order(:name).map { |i| [i.name, i.name] },
                        params[:advanced_search].try(:[], :tag))
@@ -19,5 +23,14 @@ class Shared::AdvancedSearchComponent
   def geozones_search_options
     options_for_select(Geozone.order(name: :asc).map { |g| [g.name, g.id] },
                        params[:advanced_search].try(:[], :geozone))
+  end
+
+  def council_options
+    councils = Legislation::Council.active
+                                   .with_translations(I18n.locale)
+                                   .order(:title)
+                                   .distinct
+    options_for_select(councils.map { |c| [c.title, c.title] },
+                       params[:advanced_search].try(:[], :council))
   end
 end

--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -4,7 +4,6 @@ module Search
   included do
     before_action :parse_search_terms, only: [:index, :suggest]
     before_action :parse_advanced_search_terms, only: :index
-    before_action :set_search_order, only: :index
   end
 
   def parse_search_terms
@@ -47,11 +46,5 @@ module Search
 
   def search_date_range
     [100.years.ago, search_start_date].max.beginning_of_day..[search_finish_date, Date.current].min.end_of_day
-  end
-
-  def set_search_order
-    if params[:search].present? && params[:order].blank?
-      params[:order] = "relevance"
-    end
   end
 end

--- a/app/controllers/custom/admin/legislation/councils_controller.rb
+++ b/app/controllers/custom/admin/legislation/councils_controller.rb
@@ -1,0 +1,56 @@
+class Admin::Legislation::CouncilsController < Admin::BaseController
+  include Translatable
+
+  load_and_authorize_resource :council, class: "Legislation::Council"
+  # load_and_authorize_resource
+
+  # before_action :load_councils, only: [:index]
+
+  def index
+    @counicls = Legislation::Council.all
+  end
+
+  def new
+    @council = Legislation::Council.new
+  end
+
+  def create
+    @council = Legislation::Council.new(council_params)
+
+    if @council.save
+      redirect_to admin_legislation_councils_path, notice: t("admin.council.create.notice")
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @council.update(council_params)
+      redirect_to admin_legislation_councils_path, notice: t("admin.council.update.notice")
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @council.destroy!
+    redirect_to admin_legislation_councils_path, notice: t("admin.council.delete.notice")
+  end
+
+  private
+
+    def load_councils
+      @councils = Legislation::Council.all
+    end
+
+    def council_params
+      params.require(:legislation_council).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:active, translation_params(Legislation::Council)]
+    end
+end

--- a/app/controllers/custom/admin/legislation/processes_controller.rb
+++ b/app/controllers/custom/admin/legislation/processes_controller.rb
@@ -4,6 +4,8 @@ class Admin::Legislation::ProcessesController
   include Search
   include Admin::HelpPagesActions
 
+  before_action :load_councils, only: [:index, :new, :create, :edit, :update]
+
   def index
     @processes = ::Legislation::Process.scoped_filter(params, @current_filter, @advanced_search_terms)
 
@@ -36,6 +38,10 @@ class Admin::Legislation::ProcessesController
 
   private
 
+    def load_councils
+      @councils = Legislation::Council.active
+    end
+
     def allowed_params
       [
         :start_date,
@@ -57,6 +63,7 @@ class Admin::Legislation::ProcessesController
         :draft_publication_enabled,
         :result_publication_enabled,
         :published,
+        :council_id,
         :custom_list,
         :background_color,
         :font_color,

--- a/app/controllers/custom/concerns/has_filters.rb
+++ b/app/controllers/custom/concerns/has_filters.rb
@@ -2,16 +2,6 @@ load Rails.root.join("app", "controllers", "concerns", "has_filters.rb")
 
 module HasFilters
 
-  class_methods do
-    def has_filters(valid_filters, *args)
-      before_action(*args) do
-        @valid_filters = valid_filters.respond_to?(:call) ? valid_filters.call(self) : valid_filters.dup
-        @valid_filters.delete("relevance") if params[:search].blank? && !advance_search_present?
-        @current_filter = @valid_filters.include?(params[:filter]) ? params[:filter] : @valid_filters.first
-      end
-    end
-  end
-
   private
 
     def advance_search_present?

--- a/app/controllers/custom/legislation/processes_controller.rb
+++ b/app/controllers/custom/legislation/processes_controller.rb
@@ -4,13 +4,14 @@ class Legislation::ProcessesController
   include CommentableActions
 
   before_action :load_categories, only: :index
-  before_action :set_search_filter, only: :index
-  skip_before_action :set_search_order
-  has_filters Legislation::Process.processes_filters, only: :index
+  
+  valid_filters = Legislation::Process.processes_filters
+  has_filters valid_filters, only: :index
+
   # Overwrite index of CommentableActions
   def index
     @current_filter ||= "preview_phase"
-    @processes = @search_terms.present? || advance_search_term_present? ? resource_model.all.published.not_in_draft : resource_model.send(@current_filter).published.not_in_draft
+    @processes = resource_model.send(@current_filter).published.not_in_draft
 
     if @search_terms.present?
       if @search_terms.to_i.positive?
@@ -44,12 +45,6 @@ class Legislation::ProcessesController
 
     def advance_search_term_present?
       @advanced_search_terms.present? && @advanced_search_terms.keys.map { |key| @advanced_search_terms[key].present? }.uniq.include?(true)
-    end
-
-    def set_search_filter
-      if (params[:search].present? || advance_search_present?) && params[:filter].blank?
-        params[:filter] = "relevance"
-      end
     end
 
     def order_by_phase

--- a/app/helpers/custom/admin_helper.rb
+++ b/app/helpers/custom/admin_helper.rb
@@ -40,6 +40,12 @@ module Custom::AdminHelper
     options_from_collection_for_select(targets.sort, :code, :code_and_title, selected_code)
   end
 
+  def admin_council_options(selected_code = nil)
+    councils = Legislation::Council.active
+
+    options_from_collection_for_select(councils.sort, :title, :title, selected_code)
+  end
+
   def date_range_options
     options_for_select(
       [

--- a/app/models/custom/ability.rb
+++ b/app/models/custom/ability.rb
@@ -17,6 +17,7 @@ class Ability
         can [:manage], ::Legislator
         can [:manage], ::BudgetManager
         can [:manage], ::Bulletin
+        can [:manage], ::Legislation::Council
       elsif user.legislator?
         merge Abilities::Legislator.new(user)
       elsif user.budget_manager?

--- a/app/models/custom/concerns/filterable.rb
+++ b/app/models/custom/concerns/filterable.rb
@@ -6,6 +6,11 @@ module Filterable
       scope :by_tag, ->(tag) { where(tags: { name: tag }) }
       scope :by_id, ->(id) { where(id: id) }
       scope :by_geozone, ->(id) { where(geozone_id: id) }
+      scope :by_council, ->(title) {
+        joins(council: :translations)
+          .where("legislation_council_translations.title = ?", title)
+          .where(legislation_council_translations: { locale: I18n.locale })
+      } 
 
     end
   end
@@ -14,7 +19,7 @@ module Filterable
     def allowed_filter?(filter, value)
       return if value.blank?
       
-      ["official_level", "date_range", "tag", "geozone", "id", "goal", "target"].include?(filter)
+      ["official_level", "date_range", "tag", "geozone", "id", "goal", "target", "council"].include?(filter)
     end
   end
 end

--- a/app/models/custom/legislation/council.rb
+++ b/app/models/custom/legislation/council.rb
@@ -1,0 +1,13 @@
+class Legislation::Council < ApplicationRecord
+  acts_as_paranoid column: :hidden_at
+  
+  has_many :processes, class_name: "Legislation::Process", foreign_key: "council_id", dependent: :nullify, inverse_of: :council
+
+  translates :title, touch: true
+  include Globalizable
+
+  validates :title, presence: true
+  validates_translation :title, presence: true
+
+  scope :active, -> { where(active: true) }
+end

--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -11,6 +11,8 @@ class Legislation::Process
   has_many :process_legislators, dependent: :destroy, foreign_key: "legislation_process_id" # rubocop:disable Rails/InverseOf
   has_many :legislators, through: :process_legislators
 
+  belongs_to :council, class_name: "Legislation::Council", optional: true, foreign_key: "council_id", inverse_of: :processes
+
   after_create :create_default_question
 
   def self.processes_filters

--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -16,7 +16,8 @@ class Legislation::Process
   after_create :create_default_question
 
   def self.processes_filters
-    %w[preview_phase public_phase past relevance results]
+    # %w[preview_phase public_phase past relevance results]
+    %w[preview_phase public_phase past results]
   end
 
   scope :preview_phase, -> {
@@ -55,7 +56,7 @@ class Legislation::Process
                         users.email ILIKE :like_query OR
                         legislation_process_translations.title ILIKE :like_query OR
                         legislation_councils.title ILIKE :like_query OR
-                        legislation_council_translations.name ILIKE :like_query OR
+                        legislation_council_translations.title ILIKE :like_query OR
                         legislator_users.email ILIKE :like_query",
                         like_query: "%#{search}%"
                       ).distinct
@@ -75,6 +76,7 @@ class Legislation::Process
     results = results.by_tag(params[:tag_name])          if params[:tag_name].present?
     results = results.by_goal(params[:goal])             if params[:goal].present?
     results = results.by_target(params[:target])         if params[:target].present?
+    results = results.by_council(params[:council])       if params[:council].present?
 
     results = results.search_by_title_or_id(params[:search].strip) if params[:search]
     results = results.send(current_filter) if current_filter.present?

--- a/app/models/custom/legislation/process.rb
+++ b/app/models/custom/legislation/process.rb
@@ -40,15 +40,25 @@ class Legislation::Process
   end
 
   def self.search_by_title_or_id(search)
-    with_joins = with_translations(Globalize.fallbacks(I18n.locale)).joins(:user)
+    with_joins = with_translations(Globalize.fallbacks(I18n.locale))
+      .joins(:user)
+      .left_joins(:council)
+      .joins('LEFT JOIN legislation_council_translations ON legislation_council_translations.legislation_council_id = legislation_councils.id')
+      .joins('LEFT JOIN legislation_process_legislators ON legislation_process_legislators.legislation_process_id = legislation_processes.id')
+      .joins('LEFT JOIN legislators ON legislators.id = legislation_process_legislators.legislator_id')
+      .joins('LEFT JOIN users AS legislator_users ON legislator_users.id = legislators.user_id')
 
     if search.to_s.match?(/^\d+$/)
       with_joins.where(legislation_processes: { id: search.to_i })
     else
       with_joins.where("users.username ILIKE :like_query OR
                         users.email ILIKE :like_query OR
-                        legislation_process_translations.title ILIKE :like_query",
-                       like_query: "%#{search}%")
+                        legislation_process_translations.title ILIKE :like_query OR
+                        legislation_councils.title ILIKE :like_query OR
+                        legislation_council_translations.name ILIKE :like_query OR
+                        legislator_users.email ILIKE :like_query",
+                        like_query: "%#{search}%"
+                      ).distinct
     end
   end
 

--- a/app/views/custom/admin/legislation/councils/_form.html.erb
+++ b/app/views/custom/admin/legislation/councils/_form.html.erb
@@ -1,0 +1,21 @@
+<%= render "shared/globalize_locales", resource: @council %>
+
+<%= translatable_form_for [:admin, @council] do |f| %>
+  <%= render "shared/errors", resource: @council %>
+
+  <div class="row">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="column">
+        <%= translations_form.text_field :title %>
+      </div>
+    <% end %>
+
+    <div class="column">
+      <%= f.check_box :active %>
+    </div>
+  </div>
+
+  <div class="margin-top">
+    <%= f.submit t("admin.legislation.councils.#{action_name}.submit_button"), class: "button success" %>
+  </div>
+<% end %>

--- a/app/views/custom/admin/legislation/councils/edit.html.erb
+++ b/app/views/custom/admin/legislation/councils/edit.html.erb
@@ -1,0 +1,5 @@
+<%= back_link_to admin_legislation_councils_path %>
+
+<h2><%= t("admin.legislation.councils.edit.title") %></h2>
+
+<%= render "/admin/legislation/councils/form" %>

--- a/app/views/custom/admin/legislation/councils/index.html.erb
+++ b/app/views/custom/admin/legislation/councils/index.html.erb
@@ -1,0 +1,37 @@
+<h2 class="inline-block"><%= t("admin.legislation.councils.index.title") %></h2>
+
+<%= link_to t("admin.legislation.councils.index.new"),
+            new_admin_legislation_council_path,
+            class: "button float-right margin-right" %>
+
+<% if @councils.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("admin.legislation.councils.index.table_title") %></th>
+        <th><%= t("admin.legislation.councils.index.table_active") %></th>
+        <th><%= t("admin.legislation.councils.index.table_actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @councils.each do |council| %>
+        <tr id="<%= dom_id(council) %>" class="council">
+          <td>
+            <%= council.title %>
+          </td>
+          <td>
+            <%= council.active ? t("shared.yes") : t("shared.no") %>
+          </td>
+          <td>
+            <% actions = [:edit, :destroy] %>
+            <%= render Admin::TableActionsComponent.new(council, actions: actions) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div data-alert class="callout primary margin-top clear">
+    <%= t("admin.legislation.councils.index.empty_councils") %>
+  </div>
+<% end %>

--- a/app/views/custom/admin/legislation/councils/new.html.erb
+++ b/app/views/custom/admin/legislation/councils/new.html.erb
@@ -1,0 +1,5 @@
+<%= back_link_to admin_legislation_councils_path %>
+
+<h2><%= t("admin.legislation.councils.new.title") %></h2>
+
+<%= render "/admin/legislation/councils/form" %>

--- a/app/views/custom/admin/legislation/processes/_search_form.html.erb
+++ b/app/views/custom/admin/legislation/processes/_search_form.html.erb
@@ -38,8 +38,13 @@
     <%= select_tag :target, admin_target_options(params[:targe]),
                       include_blank: t("shared.advanced_search.target_blank") %>
   </div>
+  <div class="small-12 medium-3 column">
+    <%= select_tag :council, admin_council_options(params[:council]),
+                      include_blank: t("shared.advanced_search.council_blank")
+    %>
+  </div>
 
-  <div class="small-12 medium-6 column">
+  <div class="small-12 medium-9 column">
     <div class="input-group">
       <%= text_field_tag :search, params["search"], placeholder: t("admin.shared.search.label.processes"), "aria-label": t("admin.shared.search.label.processes") %>
     </div>

--- a/app/views/custom/admin/legislation/processes/edit.html.erb
+++ b/app/views/custom/admin/legislation/processes/edit.html.erb
@@ -1,0 +1,13 @@
+<% provide :title do %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %>
+<% end %>
+
+<div class="legislation-process-edit">
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.edit.back") %>
+
+  <h2><%= @process.title %></h2>
+
+  <%= render "subnav", process: @process, active: "info" %>
+
+  <%= render Admin::Legislation::Processes::FormComponent.new(@process, councils: @councils) %>
+</div>

--- a/app/views/custom/admin/legislation/processes/index.html.erb
+++ b/app/views/custom/admin/legislation/processes/index.html.erb
@@ -27,8 +27,10 @@
         <th class="text-center"><%= t("admin.legislation.processes.process.comments") %></th>
         <% if current_user.administrator? %>
           <th class="text-center"><%= t("activerecord.models.user.one") %></th>
-          <th class="text-center">Email</th>
+          <th class="text-center"><%= t("admin.legislation.processes.process.email") %></th>
         <% end %>
+        <th class="text-center"><%= t("admin.legislation.council") %></th>
+        <th class="text-center"><%= t("admin.legislation.processes.process.legislator_email") %></th>
         <% if feature?(:sdg) %>
           <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
           <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
@@ -54,6 +56,8 @@
             <td class="text-center"><%= process.user&.username %></td>
             <td class="text-center"><%= process.user&.email %></td>
           <% end %>
+          <td class="text-center"><%= process.council&.title %></td>
+          <td class="text-center"><%= process.legislators.map(&:email).join(", ") if process.legislators.any? %></td>
           <% if feature?(:sdg) %>
             <td class="text-center"><%= process.sdg_goal_list %></td>
             <td class="text-center"><%= process.sdg_target_list %></td>

--- a/app/views/custom/admin/legislation/processes/new.html.erb
+++ b/app/views/custom/admin/legislation/processes/new.html.erb
@@ -1,0 +1,11 @@
+<% provide :title do %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= t("admin.legislation.processes.new.title") %>
+<% end %>
+
+<div class="legislation-process-new">
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.new.back") %>
+
+  <h2><%= t("admin.legislation.processes.new.title") %></h2>
+
+  <%= render Admin::Legislation::Processes::FormComponent.new(@process, councils: @councils) %>
+</div>

--- a/app/views/legislation/processes/_process.html.erb
+++ b/app/views/legislation/processes/_process.html.erb
@@ -21,6 +21,12 @@
     </div>
   </div>
 
+  <% if process.council.present?%>
+    <div class="column end">
+      <%= t("activerecord.models.legisltation/councils.one") %>: <strong><%= process.council.title %></strong>
+    </div>
+  <% end %>
+
   <% if process.enabled_phases_and_publications_count.positive? %>
     <% column_width = 12 / process.enabled_phases_and_publications_count %>
     <div class="column row">

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -15,3 +15,13 @@ en:
       alert_message/translation:
         title: Title
         description: Description
+  models:
+    legisltation/councils:
+      one: "Council"
+      other: "Councils"
+  attributes:
+    legislation/council:
+      title: Title
+      active: Active
+    legislation/council/translation:
+      title: Title

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -34,10 +34,33 @@ en:
         notice: "Alert message updated successfully"
     legislation:
       processes:
+        form:
+          admin_councils: Manage councils
         default_question_title: Tell us your opinion about this future regulatory project
         default_question_created: 'A default question has been created for the preliminary consultation phase of this process. <a href="%{link}">Click to edit it</a>.'
         default_question_creation_failed: There was a problem creating the default question for the preliminary consultation phase of this process
         default_question_create_error: 'Error creating the default question for the preliminary consultation phase of this process: %{error}'
+      council: Council
+      councils:
+        index:
+          title: Councils
+          empty_councils: No councils
+          new: New council
+          table_title: Title
+          table_active: Active
+          table_actions: Actions
+        new:
+          title: New council
+          submit_button: Create council
+        edit:
+          title: Edit council
+          submit_button: Update council
+    council:
+      create:
+        notice: Council created successfully
+        error: Council could not be created
     menu:
       site_customization:
         alert_messages: Manage alert messages
+      legislation: Legislation
+      legislation_councils: Councils

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -36,6 +36,18 @@ en:
       processes:
         form:
           admin_councils: Manage councils
+        process:
+          id: ID
+          title: Process
+          comments: Contributions to the draft
+          status: Status
+          start_date: Start date
+          end_date: End date
+          status_open: Open
+          status_closed: Closed
+          status_planned: Coming soon
+          email: Email
+          legislator_email: Legislator email
         default_question_title: Tell us your opinion about this future regulatory project
         default_question_created: 'A default question has been created for the preliminary consultation phase of this process. <a href="%{link}">Click to edit it</a>.'
         default_question_creation_failed: There was a problem creating the default question for the preliminary consultation phase of this process
@@ -64,3 +76,47 @@ en:
         alert_messages: Manage alert messages
       legislation: Legislation
       legislation_councils: Councils
+    shared:
+      true_value: "Yes"
+      false_value: "No"
+      search:
+        advanced_filters:
+          sdg_goals:
+            all: "All objectives"
+            label: "By objective"
+          sdg_targets:
+            all: "All goals"
+            label: "By goal"
+        label:
+          booths: "Search ballot box by name"
+          budget_investments: "Search projects by title, description, or item"
+          debates: "Search discussions by title or description"
+          legislation_processes: "Search processes by title or description"
+          legislation_proposals: "Search proposals by title or description"
+          local_census_records: "Search by document number"
+          organizations: "Name, email, phone number, or person in charge"
+          poll_officers: "Search for polling station presidents"
+          poll_questions: "Search for questions"
+          polls: "Search votes by name or description"
+          processes: "Search legislative processes by name, description, author, email, council, legislator, or ID"
+          proposals: "Search initiatives by title, code, description, or question"
+          users: "Search for user by name or email"
+        search: "Search"
+      search_results: "Search results"
+      no_search_results: "No results found."
+      actions: Actions
+      title: Title
+      description: Description
+      image: Image
+      show_image: Show image
+      moderated_content: "Review the content moderated by the moderators, and confirm whether the moderation has been done correctly."
+      view: View
+      proposal: Proposal
+      author: Author
+      content: Content
+      created_at: Created at
+      color_help: Hexadecimal format
+      show_results_and_stats: "Display results and statistics"
+      results_and_stats_reminder: "If you check these boxes, the results and/or statistics will be public and visible to all users."
+      close_modal: Close pop-up window
+      example_url: "For example, https://consulproject.org or /help"

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -35,7 +35,29 @@ en:
     legislation:
       processes:
         form:
-          admin_councils: Manage councils
+          enabled: Active
+          process: Process
+          process_description: Defines the total duration of the process. It includes the prior consultation (debate and proposals) and public hearing phases.
+          prior_consultation_phase: Prior consultation phase
+          prior_consultation_phase_description: "Includes two simultaneous sub-phases: Debates and Proposals. They must share the same start and end dates and both must be active."
+          debate: Debate
+          debate_description: An editable question will be automatically created to collect opinions and comments.
+          proposals: Proposals
+          proposals_description: Allows citizens to submit proposals; shares dates with Debates.
+          draft_phase: Internal drafting phase
+          draft_phase_description: If active, the process will not be public. Allows content to be prepared and reviewed before publication.
+          allegations_phase: Public hearing phase
+          allegations_phase_description: There must be a draft registered in the Draft tab.
+          draft_contributions: Contributions to the draft
+          draft_contributions_description: By activating this field, citizens will be able to make contributions to the draft.
+          draft_publication: Publication of the draft
+          draft_publication_description: By activating this field, citizens will be able to consult the draft.
+          final_result_publication: Publication of results
+          final_result_publication_description: By activating this field, the process will be displayed in the Results tab.
+          admin_councils: Manage Councils
+          use_markdown: Use Markdown to format text
+          homepage_description: Here you can explain the content of the process
+          banner_title: Header colors
         process:
           id: ID
           title: Process
@@ -48,6 +70,15 @@ en:
           status_planned: Coming soon
           email: Email
           legislator_email: Legislator email
+        subnav:
+          info: Info
+          homepage: Homepage
+          draft_versions: Draft
+          questions: Debate
+          proposals: Proposals
+          milestones: Milestones
+          legislators: Legislators
+          help_text: Help text
         default_question_title: Tell us your opinion about this future regulatory project
         default_question_created: 'A default question has been created for the preliminary consultation phase of this process. <a href="%{link}">Click to edit it</a>.'
         default_question_creation_failed: There was a problem creating the default question for the preliminary consultation phase of this process

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -438,11 +438,11 @@ es:
         end_date: Fecha de fin del proceso
         debate_start_date: Fecha de inicio del debate
         debate_end_date: Fecha de fin del debate
-        draft_start_date: Fecha de inicio del borrador
-        draft_end_date: Fecha en la que se acaba la redacción
+        draft_start_date: Fecha de inicio de elaboración interna
+        draft_end_date: Fecha de fin de elaboración interna
         draft_publication_date: Fecha de publicación del borrador
-        allegations_start_date: Fecha de inicio de alegaciones
-        allegations_end_date: Fecha de fin de alegaciones
+        allegations_start_date: Fecha de inicio de aportaciones al borrador
+        allegations_end_date: Fecha de fin de aportaciones al borrador
         proposals_phase_start_date: Fecha de inicio de propuestas
         proposals_phase_end_date: Fecha de fin de propuestas
         result_publication_date: Fecha de publicación del resultado final

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -125,6 +125,9 @@ es:
       legislation/answers:
         one: "Respuesta"
         other: "Respuestas"
+      legisltation/councils:
+        one: "Consejería"
+        other: "Consejerías"
       documents:
         one: "Documento"
         other: "Documentos"
@@ -443,6 +446,7 @@ es:
         proposals_phase_start_date: Fecha de inicio de propuestas
         proposals_phase_end_date: Fecha de fin de propuestas
         result_publication_date: Fecha de publicación del resultado final
+        council_id: Consejería
         background_color: Color del fondo
         font_color: Color del texto
         homepage_enabled: "Homepage activada"
@@ -479,6 +483,11 @@ es:
         value: Valor
       legislation/annotation:
         text: Comentario
+      legislation/council:
+        title: Título
+        active: Activo
+      legislation/council/translation:
+        title: Título
       document:
         title: Título
         attachment: "Selecciona un documento"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -715,6 +715,7 @@ es:
             title: "Ordenar por título"
             supports: "Ordenar por apoyos totales"
         process:
+          id: ID
           title: Proceso
           comments: Aportaciones al borrador
           status: Estado
@@ -723,6 +724,8 @@ es:
           status_open: Abierto
           status_closed: Cerrado
           status_planned: Próximamente
+          email: Email
+          legislator_email: Email del legislador
         subnav:
           info: Información
           homepage: Página principal
@@ -1605,7 +1608,7 @@ es:
           poll_officers: "Buscar presidentes de mesa"
           poll_questions: "Buscar preguntas"
           polls: "Buscar votaciones por nombre o descripción"
-          processes: "Buscar procesos legislativos por nombre,descripción, autor, email o id"
+          processes: "Buscar procesos legislativos por nombre,descripción, autor, email, consejería, legislador o id"
           proposals: "Buscar iniciativas por título, código, descripción o pregunta"
           users: "Buscar usuario por nombre o email"
         search: "Buscar"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -692,6 +692,7 @@ es:
           draft_phase_description: Si esta fase está activa, el proceso no aparecerá en la página de procesos. Permite previsualizar el proceso y crear contenido antes del inicio.
           allegations_phase: Fase de audiencia ciudadana
           proposals_phase: Fase de propuestas
+          admin_councils: Administrar Consejerías
           use_markdown: Usa Markdown para formatear el texto
           homepage_description: Aquí puedes explicar el contenido del proceso
           banner_title: Colores del encabezado
@@ -735,6 +736,21 @@ es:
         default_question_created: 'Se ha creado una pregunta por defecto para la fase de consulta previa de este proceso. <a href="%{link}">Haz click para editarla</a>.'
         default_question_creation_failed: Hubo un problema al crear la pregunta por defecto para la fase de consulta previa de este proceso
         default_question_create_error: 'Error al crear la pregunta por defecto para la fase de consulta previa de este proceso: %{error}'
+      council: Consejería
+      councils:
+        index:
+          title: Consejerías
+          empty_councils: No hay consejerías
+          new: Nueva consejería
+          table_title: Título
+          table_active: Activo
+          table_actions: Acciones
+        new:
+          title: Nueva consejería
+          submit_button: Crear consejería
+        edit:
+          title: Editar consejería
+          submit_button: Actualizar consejería
       homepage:
         edit:
           title: Configura la homepage del proceso
@@ -830,7 +846,10 @@ es:
             zero: "Seleccionar legisladores"
             one: "1 legislador seleccionado"
             other: "%{count} legisladores seleccionados"
-
+    council:
+      create:
+        notice: Consejería creada correctamente
+        error: No se ha podido crear la consejería
     managers:
       index:
         title: Gestores
@@ -912,6 +931,7 @@ es:
       title_site_customization: Contenido del sitio
       title_booths: Urnas de votación
       legislation: Elaboración normativa
+      legislation_councils: Consejerías
       users: Usuarios
       dashboard: Panel de progreso de iniciativas
       administrator_tasks: Recursos solicitados

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -687,11 +687,23 @@ es:
         form:
           enabled: Activa
           process: Proceso
-          debate_phase: Consulta previa
+          process_description: Define la duración total del proceso. Incluye las fases de consulta previa (debate y propuestas) y de audiencia ciudadana.
+          prior_consultation_phase: Fase de consulta previa
+          prior_consultation_phase_description: "Incluye dos subfases simultáneas: Debates y Propuestas. Deben compartir la misma fecha de inicio y fin y estar ambas activas."
+          debate: Debate
+          debate_description: Se creará automáticamente una pregunta editable para recoger opiniones y comentarios.
+          proposals: Propuestas
+          proposals_description: Permite a la ciudadanía enviar propuestas; comparte fechas con Debates.
           draft_phase: Fase de elaboración interna
-          draft_phase_description: Si esta fase está activa, el proceso no aparecerá en la página de procesos. Permite previsualizar el proceso y crear contenido antes del inicio.
+          draft_phase_description: Si está activa, el proceso no será público. Permite preparar y revisar contenido antes de su publicación.
           allegations_phase: Fase de audiencia ciudadana
-          proposals_phase: Fase de propuestas
+          allegations_phase_description: Debe existir un borrador dado de alta en la pestaña Borrador.
+          draft_contributions: Aportaciones al borrador
+          draft_contributions_description: Al activar este campo, los ciudadanos podrán hacer aportaciones al borrador.
+          draft_publication: Publicación del borrador
+          draft_publication_description: Al activar este campo, el ciudadano podrá consultar el borrador.
+          final_result_publication: Publicación de resultados
+          final_result_publication_description: Al activar este campo, el proceso se mostrará en la pestaña de Resultados.
           admin_councils: Administrar Consejerías
           use_markdown: Usa Markdown para formatear el texto
           homepage_description: Aquí puedes explicar el contenido del proceso
@@ -729,9 +741,9 @@ es:
         subnav:
           info: Información
           homepage: Página principal
-          draft_versions: Redacción
+          draft_versions: Borrador
           questions: Debate
-          proposals: Iniciativas
+          proposals: Propuestas
           milestones: Seguimiento
           legislators: Legisladores
           help_text: Texto de ayuda

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -735,6 +735,8 @@ es:
       search: "Filtrar"
       target: "Por meta"
       target_blank: "Elige una meta"
+      council: "Por consejería"
+      council_blank: "Elige una consejería"
       title: "Búsqueda avanzada"
       to: "Hasta"
       geozone: "Ámbito de actuación"

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -382,13 +382,13 @@ val:
         end_date: Data de fi del procés
         debate_start_date: Data d'inici del debat
         debate_end_date: Data de fi del debat
-        draft_start_date: Data d'inici de l'esborrany
-        draft_end_date: Data en què s'acaba la redacció
+        draft_start_date: Data d'inici de elaboració interna
+        draft_end_date: Data de fi de elaboració interna
         draft_publication_date: Data de publicació de l'esborrany
-        allegations_start_date: Data d'inici d'al·legacions
-        allegations_end_date: Data de fi d'al·legacions
-        proposals_phase_start_date: Inici
-        proposals_phase_end_date: Fi
+        allegations_start_date: Data d'inici d'aportacions a l'esborrany
+        allegations_end_date: Data de fi d'aportacions a l'esborrany
+        proposals_phase_start_date: Data d'inici de propostes
+        proposals_phase_end_date: Data de fi de propostes
         result_publication_date: Data de publicació del resultat final
         background_color: Color de fons
         font_color: Color de font

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -108,6 +108,9 @@ val:
       legislation/answers:
         one: "Resposta"
         other: "Respostes"
+      legisltation/councils:
+        one: "Conselleria"
+        other: "Conselleries"
       documents:
         one: "Document"
         other: "Documents"
@@ -423,6 +426,11 @@ val:
         value: Valor
       legislation/annotation:
         text: Comentari
+      legislation/council:
+        title: Títol
+        active: Actiu
+      legislation/council/translation:
+        title: Títol
       document:
         title: Títol
         attachment: "Fitxer adjunt"

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -464,14 +464,17 @@ val:
             title: Títol
             supports: Avals
         process:
+          id: ID
           title: Procés
           comments: Aportacions a l'esborrany
+          status: Estat
           start_date: Data d'obertura
           end_date: Data de tancament
-          status: Estat
           status_open: Oberts
           status_closed: Tancat
           status_planned: Pròximament
+          email: Email
+          legislator_email: Email del legislador
         subnav:
           info: Informació
           homepage: Pàgina principal
@@ -1209,13 +1212,25 @@ val:
       true_value: "Si"
       false_value: "No"
       search:
+        advanced_filters:
+          sdg_goals:
+            all: "Tots els objectius"
+            label: "Per objectiu"
+          sdg_targets:
+            all: "Totes les metes"
+            label: "Per meta"
         label:
           booths: "Cercar urna per nom"
+          budget_investments: "Buscar projectes per títol, descripció o partida"
           debates: "Busca debats per títol o descripció"
-          organizations: "Nom, email o telèfon"
+          legislation_processes: "Buscar processos per títol o descripció"
+          legislation_proposals: "Buscar propostes per títol o descripció"
+          local_census_records: "Busca per número de document"
+          organizations: "Nom, email, telèfon o responsable"
           poll_officers: "Cercar presidents de taula"
           poll_questions: "Cercar preguntes"
-          processes: "Cercar processos de elaboració normativa pero títol ,descripció, autor, email o id"
+          polls: "Buscar votacions per nom o descripció"
+          processes: "Buscar processos legislatius per nom,descripció, autor, email, conselleria, legislador o id"
           proposals: "Cercar iniciatives per títol, codi, descripció o pregunta"
           users: "Cercar usuari per nom o correu electrònic"
         search: "Cercar"

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -430,17 +430,25 @@ val:
         form:
           enabled: Activa
           process: Procés
-          debate_phase: Consulta prèvia
+          process_description: Definix la duració total del procés. Inclou les fases de consulta prèvia (debat i propostes) i d'audiència ciutadana.
+          prior_consultation_phase: Fase de consulta prèvia
+          prior_consultation_phase_description: "Inclou dos subfases simultànies: Debats i Propostes. Han de compartir la mateixa data d'inici i fi i estar les dos actives."
+          debate: Debat
+          debate_description: Es crearà automàticament una pregunta editable per a arreplegar opinions i comentaris.
+          proposals: Propostes
+          proposals_description: Permet a la ciutadania enviar propostes; compartix dates amb Debats.
           draft_phase: Fase de elaboració interna
-          draft_phase_description: Si aquesta fase està activa, el procés no es mostrarà en el llistat de processos. Permet una vista prèvia del procés i crea contingut abans que comence.
+          draft_phase_description: Si està activa, el procés no serà públic. Permet preparar i revisar contingut abans de la seua publicació.
           allegations_phase: Fase d'audiència ciutadana
-          proposals_phase: Fase de propostes
+          allegations_phase_description: Ha d'existir un esborrany donat d'alta en la pestanya Esborrador.
+          draft_contributions: Aportacions a l'esborrany
+          draft_contributions_description: En activar este camp, els ciutadans podran fer aportacions a l'esborrany.
+          draft_publication: Publicació de l'esborrany
+          draft_publication_description: En activar este camp, el ciutadà podrà consultar l'esborrany.
+          final_result_publication: Publicació de resultats
+          final_result_publication_description: En activar este camp, el procés es mostrarà en la pestanya de Resultats.
           admin_councils: Administrar Conselleries
           use_markdown: Usa Markdown per a formatejar el text
-          title_placeholder: Escriu el títol del procés
-          summary_placeholder: Resum curt de la descripció
-          description_placeholder: Afegeix una descripció del procés
-          additional_info_placeholder: Afegeix qualsevol informació addicional que puga ser d'interès
           homepage_description: Ací pots explicar el contingut del procés
           banner_title: Colors de capçalera
         index:
@@ -478,7 +486,7 @@ val:
         subnav:
           info: Informació
           homepage: Pàgina principal
-          draft_versions: Redacció
+          draft_versions: Esborrany
           questions: Debat
           proposals: Propostes
           milestones: Seguiment

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -435,6 +435,7 @@ val:
           draft_phase_description: Si aquesta fase està activa, el procés no es mostrarà en el llistat de processos. Permet una vista prèvia del procés i crea contingut abans que comence.
           allegations_phase: Fase d'audiència ciutadana
           proposals_phase: Fase de propostes
+          admin_councils: Administrar Conselleries
           use_markdown: Usa Markdown per a formatejar el text
           title_placeholder: Escriu el títol del procés
           summary_placeholder: Resum curt de la descripció
@@ -484,6 +485,21 @@ val:
         default_question_created: S'ha creat una pregunta per defecte per a la fase de consulta prèvia d'este procés. <a href="%{link}">Feix clic per a editar-la</a>.
         default_question_creation_failed: Va haver-hi un problema en crear la pregunta per defecte per a la fase de consulta prèvia d'este procés
         default_question_create_error: "Error en crear la pregunta per defecte per a la fase de consulta prèvia d'este procés: %{error}"
+      council: Conselleria
+      councils:
+        index:
+          title: Conselleries
+          empty_councils: No hi ha conselleries
+          new: Nova conselleria
+          table_title: Títol
+          table_active: Activa
+          table_actions: Accions
+        new:
+          title: Nova conselleria
+          submit_button: Crear conselleria
+        edit:
+          title: Editar conselleria
+          submit_button: Actualitzar conselleria
       homepage:
         edit:
           title: Configura la teua pàgina principal
@@ -654,6 +670,7 @@ val:
       title_site_customization: Personalitzar lloc
       title_booths: Cabines de vot
       legislation: Elaboració normativa
+      legislation_councils: Conselleries
       users: Usuaris
     administrators:
       index:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -43,8 +43,8 @@ namespace :admin do
     end
 
     resources :debates, only: [:index, :show] do
-    get :help_page, on: :collection # Custom
-  end
+      get :help_page, on: :collection # Custom
+    end
 
     resources :proposals, only: [:index, :show, :update] do
       member do
@@ -55,7 +55,7 @@ namespace :admin do
       resources :milestones, controller: "proposal_milestones"
       resources :progress_bars, except: :show, controller: "proposal_progress_bars"
       get :help_page, on: :collection # Custom
-  end
+    end
 
     resources :hidden_proposals, only: :index do
       member do
@@ -105,7 +105,7 @@ namespace :admin do
         end
       end
       get :help_page, on: :collection # Custom
-  end
+    end
 
     namespace :budgets_wizard do
       resources :budgets, only: [:create, :new, :edit, :update] do
@@ -130,11 +130,11 @@ namespace :admin do
       collection { get :search }
     end
 
-  resources :alert_messages, only: [:index, :new, :create, :edit, :update, :destroy] do
-    collection { get :search }
-  end
+    resources :alert_messages, only: [:index, :new, :create, :edit, :update, :destroy] do
+      collection { get :search }
+    end
 
-  resources :key_systems, only: [:index] # Custom
+    resources :key_systems, only: [:index] # Custom
 
     resources :hidden_comments, only: :index do
       member do
@@ -193,7 +193,7 @@ namespace :admin do
         resources :recounts, only: :index
         resources :results, only: :index
         get :help_page, on: :collection # Custom
-    end
+      end
 
       resources :officers, only: [:index, :new, :create, :destroy] do
         get :search, on: :collection
@@ -223,16 +223,16 @@ namespace :admin do
     resources :verifications, controller: :verifications, only: :index do
       get :search, on: :collection
       # Added by usabi for two phase verification
-    put :request_verification, on: :collection
-  end
-
-  resource :activity, controller: :activity, only: :show
-
-  resources :bulletins do # Custom
-    member do
-      post :deliver
+      put :request_verification, on: :collection
     end
-  end
+
+    resource :activity, controller: :activity, only: :show
+
+    resources :bulletins do # Custom
+      member do
+        post :deliver
+      end
+    end
 
     resources :newsletters do
       member do
@@ -264,7 +264,7 @@ namespace :admin do
       get :budget_supporting, on: :member
       get :budget_balloting, on: :member
       get :budget_stats, on: :member
-    get :proposal_notifications, on: :collection
+      get :proposal_notifications, on: :collection
       get :direct_messages, on: :collection
       get :polls, on: :collection
       get :sdg, on: :collection
@@ -279,15 +279,15 @@ namespace :admin do
             patch :deselect
           end
           get :summary, on: :collection # Custom
-      end
+        end
         resources :draft_versions
         resources :milestones
         resources :progress_bars, except: :show
         resource :homepage, only: [:edit, :update]
         resource :legislators, only: [:edit, :update] # Custom
-      resource :help_pages, only: [:show] # Custom
-      get :help_page, on: :collection # Custom
-    end
+        resource :help_pages, only: [:show] # Custom
+        get :help_page, on: :collection # Custom
+      end
       resources :councils # Custom
     end
 
@@ -299,7 +299,7 @@ namespace :admin do
         resources :cards, except: [:show], as: :widget_cards
       end
       resources :help_texts # Custom
-    resources :images, only: [:index, :update, :destroy]
+      resources :images, only: [:index, :update, :destroy]
       resources :content_blocks, except: [:show]
       delete "/heading_content_blocks/:id", to: "content_blocks#delete_heading_content_block",
                                             as: "delete_heading_content_block"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -288,6 +288,7 @@ namespace :admin do
       resource :help_pages, only: [:show] # Custom
       get :help_page, on: :collection # Custom
     end
+      resources :councils # Custom
     end
 
     resources :geozones, only: [:index, :new, :create, :edit, :update, :destroy]

--- a/db/migrate/20250916113000_create_legislation_councils.rb
+++ b/db/migrate/20250916113000_create_legislation_councils.rb
@@ -1,0 +1,12 @@
+class CreateLegislationCouncils < ActiveRecord::Migration[4.2]
+  def change
+    create_table :legislation_councils do |t|
+      t.string   "title", limit: 80
+      t.boolean  "active", default: true
+      t.datetime "hidden_at"
+
+      t.timestamps null: false
+      t.index :hidden_at
+    end
+  end
+end

--- a/db/migrate/20250916120000_add_council_translations.rb
+++ b/db/migrate/20250916120000_add_council_translations.rb
@@ -1,0 +1,20 @@
+class AddCouncilTranslations < ActiveRecord::Migration[6.1]
+  def self.up
+    I18n.locale = :es
+    create_table :legislation_council_translations do |t|
+      t.references :legislation_council, null: false, foreign_key: { to_table: :legislation_councils }, index: false
+      t.string :title
+      t.string :locale, null: false
+      t.datetime :hidden_at, index: true
+      t.timestamps
+    end
+
+    add_index :legislation_council_translations,
+              [:legislation_council_id, :locale],
+              name: 'idx_leg_pr_council_translations'
+  end
+
+  def self.down
+    drop_table :legislation_council_translations
+  end
+end

--- a/db/migrate/20250916130000_add_council_to_legislation_process.rb
+++ b/db/migrate/20250916130000_add_council_to_legislation_process.rb
@@ -1,0 +1,7 @@
+class AddCouncilToLegislationProcess < ActiveRecord::Migration[6.1]
+  def change
+    add_column :legislation_processes, :council_id, :integer
+    add_index :legislation_processes, :council_id
+    add_foreign_key :legislation_processes, :legislation_councils, column: :council_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_29_130118) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_16_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -764,6 +764,26 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_29_130118) do
     t.index ["user_id"], name: "index_legislation_answers_on_user_id"
   end
 
+  create_table "legislation_council_translations", force: :cascade do |t|
+    t.bigint "legislation_council_id", null: false
+    t.string "title"
+    t.string "locale", null: false
+    t.datetime "hidden_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["hidden_at"], name: "index_legislation_council_translations_on_hidden_at"
+    t.index ["legislation_council_id", "locale"], name: "idx_leg_pr_council_translations"
+  end
+
+  create_table "legislation_councils", id: :serial, force: :cascade do |t|
+    t.string "title", limit: 80
+    t.boolean "active", default: true
+    t.datetime "hidden_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["hidden_at"], name: "index_legislation_councils_on_hidden_at"
+  end
+
   create_table "legislation_draft_version_translations", id: :serial, force: :cascade do |t|
     t.integer "legislation_draft_version_id", null: false
     t.string "locale", null: false
@@ -845,8 +865,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_29_130118) do
     t.text "font_color"
     t.bigint "user_id"
     t.tsvector "tsv"
+    t.integer "council_id"
     t.index ["allegations_end_date"], name: "index_legislation_processes_on_allegations_end_date"
     t.index ["allegations_start_date"], name: "index_legislation_processes_on_allegations_start_date"
+    t.index ["council_id"], name: "index_legislation_processes_on_council_id"
     t.index ["debate_end_date"], name: "index_legislation_processes_on_debate_end_date"
     t.index ["debate_start_date"], name: "index_legislation_processes_on_debate_start_date"
     t.index ["draft_end_date"], name: "index_legislation_processes_on_draft_end_date"
@@ -1910,9 +1932,11 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_29_130118) do
   add_foreign_key "geozones_polls", "polls"
   add_foreign_key "identities", "users"
   add_foreign_key "images", "users"
+  add_foreign_key "legislation_council_translations", "legislation_councils"
   add_foreign_key "legislation_draft_versions", "legislation_processes"
   add_foreign_key "legislation_process_legislators", "legislation_processes"
   add_foreign_key "legislation_process_legislators", "legislators"
+  add_foreign_key "legislation_processes", "legislation_councils", column: "council_id"
   add_foreign_key "legislation_processes", "users"
   add_foreign_key "legislation_proposals", "legislation_processes"
   add_foreign_key "legislators", "users"

--- a/spec/components/admin/legislation/processes/form_component_spec.rb
+++ b/spec/components/admin/legislation/processes/form_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Admin::Legislation::Processes::FormComponent, :admin do
   let(:process) { build(:legislation_process) }
-  let(:component) { Admin::Legislation::Processes::FormComponent.new(process) }
+  let(:component) { Admin::Legislation::Processes::FormComponent.new(process, councils: @councils) }
 
   describe "background color fields" do
     it "renders two inputs sharing the same label" do

--- a/spec/factories/custom/legislation_councils.rb
+++ b/spec/factories/custom/legislation_councils.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :legislation_council, class: "Legislation::Council" do
+    name { Faker::Company.name }
+    active { true }
+
+    trait :inactive do
+      active { false }
+    end
+  end
+end

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -100,6 +100,13 @@ FactoryBot.define do
     trait :with_milestone_tags do
       after(:create) { |legislation| legislation.milestone_tags << create(:tag, :milestone) }
     end
+
+    trait :with_council do
+      after(:create) do |legislation|
+        legislation.council = create(:legislation_council)
+        legislation.save!
+      end
+    end
   end
 
   factory :legislation_draft_version, class: "Legislation::DraftVersion" do

--- a/spec/models/custom/legislation/councils_spec.rb
+++ b/spec/models/custom/legislation/councils_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe Legislation::Council do
+  let(:council) { create(:legislation_council) }
+
+  it_behaves_like "acts as paranoid", :legislation_council
+  it_behaves_like "globalizable", :legislation_council
+
+  describe "validations" do
+    it "is valid" do
+      expect(council).to be_valid
+    end
+
+    it "is not valid without a name" do
+      council.name = nil
+      expect(council).not_to be_valid
+    end
+
+    describe "translations" do
+      it "is not valid without a translated name" do
+        council.translations.first.name = nil
+        expect(council).not_to be_valid
+      end
+    end
+  end
+
+  describe "associations" do
+    it "has many processes" do
+      process1 = create(:legislation_process)
+      process2 = create(:legislation_process)
+      
+      council.processes << process1
+      council.processes << process2
+
+      expect(council.processes).to include(process1)
+      expect(council.processes).to include(process2)
+    end
+
+    it "nullifies processes when destroyed" do
+      process = create(:legislation_process)
+      council.processes << process
+      
+      council.destroy
+
+      process.reload
+      expect(process.council_id).to be_nil
+    end
+  end
+
+  describe "scopes" do
+    let!(:active_council) { create(:legislation_council) }
+    let!(:inactive_council) { create(:legislation_council, :inactive) }
+
+    it "active returns only active councils" do
+      expect(Legislation::Council.active).to include(active_council)
+      expect(Legislation::Council.active).not_to include(inactive_council)
+    end
+  end
+
+  describe "paranoia" do
+    it "hides council using hidden_at" do
+      council.destroy
+      expect(council.hidden_at).to be_present
+    end
+
+    it "restores hidden council" do
+      council.destroy
+      council.restore
+      expect(council.hidden_at).to be_nil
+    end
+  end
+end

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -341,6 +341,30 @@ describe Legislation::Process do
     end
   end
 
+  describe "councils" do
+    context "without council" do
+      let(:process) { create(:legislation_process) }
+
+      it "do not have council" do
+        expect(process.council).to be_nil
+      end
+
+      it "add a new council" do
+        council = create(:legislation_council)
+        process.council = council
+
+        expect(process.council).to eq(council)
+      end
+    end
+    context "with council" do
+      let(:process) { create(:legislation_process, :with_council) }
+
+      it "has council" do
+        expect(process.council).to be_present
+      end
+    end
+  end
+
   describe ".search" do
     let!(:traffic) do
       create(:legislation_process,

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Admin collaborative legislation", :admin do
+describe "Admin collaborative legislation", :admin, :consul do
   it_behaves_like "admin_milestoneable",
                   :legislation_process,
                   "admin_legislation_process_milestones_path"

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -26,7 +26,6 @@ describe "Stats", :admin do
 
       in_browser(:different) do
         visit root_path
-        debugger
         click_link "Debates"
         expect(page).to have_link "Start a debate"
 

--- a/spec/system/custom/admin/legislation/processes_spec.rb
+++ b/spec/system/custom/admin/legislation/processes_spec.rb
@@ -5,12 +5,57 @@ describe "Admin collaborative legislation", :admin do
                   :legislation_process,
                   "admin_legislation_process_milestones_path"
 
+  context "Index" do
+    scenario "Displaying collaborative legislation" do
+      process_1 = create(:legislation_process, title: "Process open")
+      process_2 = create(:legislation_process, title: "Process for the future",
+                                               start_date: Date.current + 5.days)
+      process_3 = create(:legislation_process, title: "Process closed",
+                                               start_date: Date.current - 10.days,
+                                               end_date: Date.current - 6.days)
+
+      visit admin_legislation_processes_path(filter: "active")
+
+      expect(page).to have_content(process_1.title)
+      expect(page).to have_content(process_2.title)
+      expect(page).not_to have_content(process_3.title)
+
+      visit admin_legislation_processes_path(filter: "all")
+
+      expect(page).to have_content(process_1.title)
+      expect(page).to have_content(process_2.title)
+      expect(page).to have_content(process_3.title)
+    end
+
+    scenario "Processes are sorted by descending start date", consul: true do
+      process_1 = create(:legislation_process, title: "Process 1", start_date: Date.yesterday)
+      process_2 = create(:legislation_process, title: "Process 2", start_date: Date.current)
+      process_3 = create(:legislation_process, title: "Process 3", start_date: Date.tomorrow)
+
+      visit admin_legislation_processes_path(filter: "all")
+
+      expect(page).to have_content process_1.start_date
+      expect(page).to have_content process_2.start_date
+      expect(page).to have_content process_3.start_date
+
+      expect(page).to have_content process_1.end_date
+      expect(page).to have_content process_2.end_date
+      expect(page).to have_content process_3.end_date
+
+      expect(process_3.title).to appear_before(process_2.title)
+      expect(process_2.title).to appear_before(process_1.title)
+    end
+  end
+
   context "Create" do
     scenario "Valid legislation process" do
       visit admin_root_path
 
       within("#side_menu") do
-        click_link "Collaborative Legislation"
+        click_button "Legislation"
+        within("#legislation_menu") do
+          click_link "Legislation"
+        end
       end
 
       expect(page).not_to have_content "An example legislation process"

--- a/spec/system/legislation/processes_spec.rb
+++ b/spec/system/legislation/processes_spec.rb
@@ -43,7 +43,7 @@ describe "Legislation" do
       end
     end
 
-    scenario "Processes are sorted by descending start date" do
+    scenario "Processes are sorted by descending start date", :consul do
       create(:legislation_process, title: "Process 1", start_date: 3.days.ago)
       create(:legislation_process, title: "Process 2", start_date: 2.days.ago)
       create(:legislation_process, title: "Process 3", start_date: Date.yesterday)


### PR DESCRIPTION
## References
issue/8412 Crear tabla de consellerías
issue/8411 Añadir email de legislador y conselleria en tablas
issue/8414 Añadir filtro por Conselleria (back y front)
issue/8410 Igualación de textos en la interfaz de Elaboración Normativa

## Objectives

> Add legislation councils. Within the new and edit legislation process form, a new council select has been added.
Administrators can manage them.

> There are a new crud for Councils too

## Visual Changes

> <img width="749" height="498" alt="image" src="https://github.com/user-attachments/assets/a9722f16-457d-4b4e-bb13-f5a483773075" />

> <img width="1260" height="607" alt="image" src="https://github.com/user-attachments/assets/1c395805-7ce4-4584-9504-ced289629d72" />
