### PR TITLE
feat: Admins can mark a proposal as duplicated of other one

### DIFF
--- a/app/controllers/custom/admin/proposals_controller.rb
+++ b/app/controllers/custom/admin/proposals_controller.rb
@@ -23,4 +23,10 @@ class Admin::ProposalsController
     @help_text_content = help_text(controller_name)
     render "admin/proposals/help_pages/show"
   end
+
+  private
+
+    def allowed_params
+      [:selected, :duplicated_of_proposal_id]
+    end
 end

--- a/app/controllers/custom/admin/system_emails_controller.rb
+++ b/app/controllers/custom/admin/system_emails_controller.rb
@@ -4,6 +4,7 @@ class Admin::SystemEmailsController
   def index
     @system_emails = {
       proposal_notification_digest:       %w[view preview_pending],
+      duplicated_proposal_for_author:     %w[view edit_info],
       budget_investment_created:          %w[view edit_info],
       budget_investment_selected:         %w[view edit_info],
       budget_investment_unfeasible:       %w[view edit_info],
@@ -20,4 +21,35 @@ class Admin::SystemEmailsController
       evaluation_comment:                 %w[view edit_info]
     }
   end
+
+  def view
+    case @system_email
+    when "proposal_notification_digest"
+      load_sample_proposal_notifications
+    when "duplicated_proposal_for_author"
+      load_sample_duplicated_proposal
+    when /\Abudget_investment/
+      load_sample_investment
+    when /\Adirect_message/
+      load_sample_direct_message
+    when "comment"
+      load_sample_comment
+    when "reply"
+      load_sample_reply
+    when "email_verification"
+      load_sample_user
+    when "user_invite"
+      @subject = t("mailers.user_invite.subject", org_name: Setting["org_name"])
+    when "evaluation_comment"
+      load_sample_valuation_comment
+    end
+  end
+
+  private
+
+    def load_sample_duplicated_proposal
+      @subject = t("mailers.duplicated_proposal_for_author.subject", proposal_title: t("mailers.duplicated_proposal_for_author.sample.proposal.title"))
+      @proposal = Proposal.new(title: t("mailers.duplicated_proposal_for_author.sample.proposal.title"), description: t("mailers.duplicated_proposal_for_author.sample.proposal.description"))
+      @original_proposal = Proposal.new(title: t("mailers.duplicated_proposal_for_author.sample.original_proposal.title"), description: t("mailers.duplicated_proposal_for_author.sample.original_proposal.description"))
+    end
 end

--- a/app/controllers/custom/proposals_controller.rb
+++ b/app/controllers/custom/proposals_controller.rb
@@ -1,0 +1,9 @@
+load Rails.root.join("app", "controllers", "proposals_controller.rb")
+
+class ProposalsController
+  def retire_form
+    @proposal = Proposal.find(params[:id])
+    @proposal.retired_reason = params[:retired_reason] if params[:retired_reason].present?
+    @proposal.retired_explanation = params[:retired_explanation] if params[:retired_explanation].present?
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -73,6 +73,14 @@ class Mailer < ApplicationMailer
     end
   end
 
+  def duplicated_proposal_for_author(author, proposal)
+    @proposal = proposal
+    @original_proposal = Proposal.find(@proposal.duplicated_of_proposal_id)
+    @email_to = author.email
+    
+    mail(to: @email_to, subject: t('mailers.duplicated_proposal_for_author.subject', proposal_title: @proposal.title))
+  end
+
   def user_invite(email)
     @email_to = email
 

--- a/app/models/custom/proposal.rb
+++ b/app/models/custom/proposal.rb
@@ -3,10 +3,34 @@ load Rails.root.join("app", "models", "proposal.rb")
 class Proposal
   SORTING_OPTIONS = { id: "id", supports: "cached_votes_up", created_at: "created_at" }.freeze
 
+  belongs_to :duplicated_of_proposal, class_name: "Proposal", optional: true
+  has_many :duplicates, class_name: "Proposal", foreign_key: :duplicated_of_proposal_id, dependent: :nullify
+
+  after_update :send_duplicated_proposal_email, if: :saved_change_to_duplicated_of_proposal_id?
+
   scope :sort_by_id,               -> { order("id DESC") }
   scope :sort_by_supports,         -> { order("cached_votes_up DESC") }
   scope :sort_by_selected,         -> { selected }
   scope :by_tag,                   ->(tag_name) { tagged_with(tag_name).distinct }
+  scope :duplicable,            -> { published
+                                     .not_retired
+                                     .not_archived }
+
+  def duplicated?
+    duplicated_of_proposal.present?
+  end
+
+  def saved_change_to_duplicated_of_proposal_id?
+    saved_change_to_attribute?(:duplicated_of_proposal_id)
+  end
+
+  def send_duplicated_proposal_email
+    return unless duplicated_of_proposal.present? && saved_change_to_duplicated_of_proposal_id?
+
+    Mailer.duplicated_proposal_for_author(author, self).deliver_now
+  rescue StandardError => e
+    Rails.logger.error("Error sending duplicated proposal email: #{e.message}")
+  end
 
   def self.sort_by_title
     all.sort_by(&:title)

--- a/app/views/custom/admin/proposals/_form.html.erb
+++ b/app/views/custom/admin/proposals/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_for [:admin, @proposal] do |f| %>
+
+  <%= render "shared/errors", resource: @proposal %>
+
+  <%= f.check_box :selected %>
+
+  <hr>
+
+  <div class="small-12 column">
+    <%= f.collection_select :duplicated_of_proposal_id,
+                            Proposal.where.not(id: @proposal.id)
+                                    .duplicable
+                                    .order(:id),
+                            :id,
+                            :title,
+                            include_blank: true,
+                            class: "view_in_new_tab" %>
+    <legend">
+      <span class="help-text">
+        <%= t("admin.proposals.form.duplicated_of_proposal_description", link: link_to(t("admin.proposals.form.here"), admin_system_email_view_path('duplicated_proposal_for_author'))).html_safe %>
+      </span>
+    </legend>
+  </div>
+
+  <hr>
+
+  <%= f.submit t("admin.proposals.form.update"), class: "button success" %>
+
+<% end %>

--- a/app/views/custom/admin/proposals/index.html.erb
+++ b/app/views/custom/admin/proposals/index.html.erb
@@ -27,6 +27,7 @@
         <th><%= t("admin.proposals.index.sdg") %></th>
         <th><%= t("admin.proposals.index.target") %></th>
         <th><%= t("admin.proposals.index.tags") %></th>
+        <th><%= t("admin.proposals.index.duplicated") %></th>
         <th><%= t("admin.proposals.index.selected") %></th>
       </tr>
     </thead>
@@ -43,6 +44,7 @@
           <td><%= proposal.sdg_goal_list %></td>
           <td><%= proposal.sdg_target_list %></td>
           <td><%= proposal.tags_list.join(", ") %></td>
+          <td><%= t("admin.proposals.index.duplicated") if proposal.duplicated_of_proposal.present? %></td>
           <td><%= render Admin::Proposals::ToggleSelectionComponent.new(proposal) %></td>
         </tr>
       <% end %>

--- a/app/views/custom/mailer/duplicated_proposal_for_author.html.erb
+++ b/app/views/custom/mailer/duplicated_proposal_for_author.html.erb
@@ -1,0 +1,30 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.duplicated_proposal_for_author.hi") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.duplicated_proposal_for_author.explanation", title: @proposal.title) %>
+  </p>
+
+  <h3 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; padding-left: 12px; border-left: 2px solid #ccc;">
+    <strong><%= link_to @original_proposal.title, proposal_url(@original_proposal) %></strong><br>
+  </h3>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.duplicated_proposal_for_author.options") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.duplicated_proposal_for_author.action") %>
+    <%= link_to "Retirar propuesta",
+                retire_form_proposal_url(@proposal,
+                                         retired_reason: "duplicated", 
+                                         retired_explanation: "Esta propuesta ya existe como duplicada") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.duplicated_proposal_for_author.sincerely") %>
+  </p>
+</td>

--- a/app/views/custom/proposals/retire_form.html.erb
+++ b/app/views/custom/proposals/retire_form.html.erb
@@ -1,0 +1,45 @@
+<div class="proposal-edit row">
+
+  <div class="small-12 column">
+
+    <h1 class="inline-block"><%= t("proposals.retire_form.title") %></h1>
+
+    <h3><%= link_to @proposal.title, @proposal %></h3>
+
+    <div data-alert class="callout warning">
+     <%= t("proposals.retire_form.warning") %>
+    </div>
+
+    <%= render "shared/globalize_locales", resource: @proposal, manage_languages: false %>
+
+    <%= translatable_form_for(@proposal, url: retire_proposal_path(@proposal)) do |f| %>
+      <%= render "shared/errors", resource: @proposal %>
+      <div class="row column">
+        <div class="small-12 medium-6 large-4 column">
+          <%= f.select :retired_reason,
+                       retire_proposals_options,
+                       include_blank: t("proposals.retire_form.retired_reason_blank") %>
+        </div>
+      </div>
+
+      <div class="row column">
+        <%= f.translatable_fields do |translations_form| %>
+          <div class="small-12 medium-9 column float-left">
+            <%= translations_form.text_area :retired_explanation,
+                                            rows: 4,
+                                            maxlength: 500,
+                                            placeholder: t("proposals.retire_form.retired_explanation_placeholder"),
+                                            value: @proposal.retired_explanation if @proposal.retired_explanation.present? %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="row column">
+        <div class="actions small-12 medium-3 column">
+          <%= f.submit(class: "button expanded", value: t("proposals.retire_form.submit_button")) %>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -1,0 +1,127 @@
+<% provide :title, @proposal.title %>
+<% preview = false unless local_assigns.has_key? :preview %>
+<% content_for :meta_description do %><%= @proposal.summary %><% end %>
+<% provide :social_media_meta_tags do %>
+  <%= render "shared/social_media_meta_tags",
+             social_url: proposal_url(@proposal),
+             social_title: @proposal.title,
+             social_description: @proposal.summary,
+             twitter_image_url: (@proposal.image.present? ? polymorphic_path(@proposal.image.variant(:thumb)) : nil),
+             og_image_url: (@proposal.image.present? ? polymorphic_path(@proposal.image.variant(:thumb)) : nil) %>
+<% end %>
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: proposal_url(@proposal) %>
+<% end %>
+
+<% cache [locale_and_user_status(@proposal),
+          @proposal,
+          @proposal.author,
+          Flag.flagged?(current_user, @proposal),
+          @proposal.followed_by?(current_user),
+          current_user&.voted_for?(@proposal)] do %>
+  <div class="proposal-show">
+    <div id="<%= dom_id(@proposal) %>" class="row">
+      <div class="small-12 medium-9 column">
+        <%= back_link_to proposals_path unless preview %>
+
+        <h1><%= @proposal.title %></h1>
+        <% if @proposal.retired? %>
+          <div data-alert class="callout alert margin-top proposal-retired">
+            <strong>
+              <%= t("proposals.show.retired_warning") %><br>
+              <%= link_to t("proposals.show.retired_warning_link_to_explanation"),
+                          "#retired_explanation" %>
+            </strong>
+          </div>
+        <% elsif @proposal.conflictive? %>
+          <div data-alert class="callout alert margin-top">
+            <strong><%= t("proposals.show.flag") %></strong>
+          </div>
+        <% elsif @proposal.duplicated? %>
+          <div data-alert class="callout alert margin-top">
+            <strong><%= t("proposals.show.duplicated") %></strong>
+            <div>
+              <%= t("proposals.show.duplicated_description", link_to_original: link_to(@proposal.duplicated_of_proposal.title, proposal_path(@proposal.duplicated_of_proposal))).html_safe %>
+            </div>
+          </div>
+        <% elsif @proposal.duplicates.present? %>
+          <div data-warning class="callout warning margin-top">
+            <strong><%= t("proposals.show.original") %></strong>
+            <div>
+              <%= t("proposals.show.original_description") %>
+              <ul>
+                <% @proposal.duplicates.each do |duplicate| %>
+                  <li>
+                    <%= link_to duplicate.title, proposal_path(duplicate) %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        <% end %>
+
+        <%= render "proposals/info", proposal: @proposal %>
+        <%= render Shared::GeozoneLinkComponent.new(@proposal, proposals_path(search: geozone_name(@proposal))) %>
+
+        <% unless @proposal.selected? %>
+          <%= render "relationable/related_content", relationable: @proposal %>
+        <% end %>
+
+        <div class="js-moderator-proposal-actions margin">
+          <%= render "proposals/actions", proposal: @proposal %>
+        </div>
+      </div>
+
+      <% unless preview %>
+        <aside class="small-12 medium-3 column">
+          <% if can?(:dashboard, @proposal) %>
+            <div class="sidebar-divider"></div>
+            <h2><%= t("proposals.show.author") %></h2>
+            <div class="show-actions-menu">
+              <%= link_to progress_proposal_dashboard_path(@proposal),
+                          class: "button hollow expanded",
+                          id: "proposal-dashboard-#{@proposal.id}" do %>
+                <span class="icon-edit"></span>
+                <%= t("proposals.show.dashboard_proposal_link") %>
+              <% end %>
+            </div>
+          <% end %>
+
+          <%= render "proposals/support_status", proposal: @proposal %>
+
+          <%= render "proposals/social_share", proposal: @proposal, share_title: t("proposals.show.share") %>
+
+          <% if current_user %>
+            <div class="sidebar-divider"></div>
+            <p class="sidebar-title"><%= t("shared.follow") %></p>
+
+            <%= render "follows/follow_button", follow: find_or_build_follow(current_user, @proposal) %>
+          <% end %>
+
+          <%= render "communities/access_button", community: @proposal.community %>
+        </aside>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% unless preview %>
+  <div class="additional-content">
+    <div class="filter-subnav">
+      <div class="row">
+        <div class="small-12 column">
+          <%= render "proposals/filter_subnav" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="tabs-content" data-tabs-content="proposals_tabs">
+    <div class="tabs-panel is-active" id="tab-comments">
+      <%= render "proposals/comments" %>
+    </div>
+
+    <%= render "proposals/notifications" %>
+    <%= render "milestones/milestones", milestoneable: @proposal %>
+  </div>
+<% end %>

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -15,6 +15,17 @@ en:
       alert_message/translation:
         title: Title
         description: Description
+      proposal:
+        author: "Author"
+        title: "Title"
+        question: "Question"
+        description: "Description"
+        responsible_name: "Name and surname of the person who makes this proposal"
+        retired_reason: "Reason for retiring the proposal"
+        selected: "Mark as selected"
+        duplicated_of_proposal_id: "Duplicated proposal of"
+        terms_of_service: "Terms of service"
+        video_url: "External video link"
   models:
     legisltation/councils:
       one: "Council"

--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -151,3 +151,14 @@ en:
       results_and_stats_reminder: "If you check these boxes, the results and/or statistics will be public and visible to all users."
       close_modal: Close pop-up window
       example_url: "For example, https://consulproject.org or /help"
+
+    system_emails:
+      duplicated_proposal_for_author:
+        title: "Duplicated proposal"
+        description: "Sent to the author of a proposal when it is marked as duplicated."
+
+    proposals:
+      form:
+        update: Update proposal
+        duplicated_of_proposal_description: "The author of this initiative will receive an email notification. You can view the email template %{link}."
+        here: "here"

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -409,9 +409,17 @@ en:
     show:
       author_deleted: User deleted
       code: "Proposal code:"
+      comments:
+        zero: No comments
+        one: 1 Comment
+        other: "%{count} Comments"
       comments_tab: Comments
       dashboard_proposal_link: Dashboard
       flag: This proposal has been flagged as inappropriate by several users.
+      duplicated: Duplicated proposal
+      duplicated_description: This proposal has been marked as a duplicate of the proposal %{link_to_original}.
+      original: Original proposal
+      original_description: "This proposal is the original of the following duplicated proposals:"
       notifications_tab: Notifications
       milestones_tab: Milestones
       retired_warning: "The author considers this proposal should not receive more supports."

--- a/config/locales/custom/en/mailer.yml
+++ b/config/locales/custom/en/mailer.yml
@@ -1,0 +1,16 @@
+en:
+  mailers:
+    duplicated_proposal_for_author:
+      sample:
+        proposal:
+          title: 'TITLE OF YOUR PROPOSAL'
+          descripción: 'DESCRIPTION OF YOUR PROPOSAL'
+        original_proposal:
+          title: 'TITLE OF THE ORIGINAL PROPOSAL'
+          descripción: 'DESCRIPTION OF THE ORIGINAL PROPOSAL'
+      subject: "Your proposal %{proposal_title} is similar to another one"
+      hi: Hi
+      explanation: "We have detected that the proposal %{title} you have submitted is very similar to another one that already exists on the platform. This can happen for several reasons, such as the proposal having been duplicated by mistake or the topic having already been addressed previously. We believe that the related proposal that will unify similar proposals is the following:"
+      options: 'We recommend reviewing the existing proposal to see if it aligns with your ideas or if you can contribute to it. In this case, you should withdraw your proposal (see below for instructions on how to do so). If you believe your proposal is different and deserves to be considered separately, please contact us so we can review it manually.'
+      action: "To withdraw your proposal, click on the following link:"
+      sincerely: We appreciate your participation and encourage you to continue contributing new ideas and proposals.

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -276,6 +276,7 @@ es:
         responsible_name: "Nombre y apellidos de la persona que hace esta propuesta"
         retired_reason: "Razón por la que se retira la propuesta"
         selected: "Marcar como seleccionada"
+        duplicated_of_proposal_id: "Iniciativa duplicada de"
         terms_of_service: "Términos de servicio"
         video_url: "Enlace a vídeo externo"
       proposal/translation:

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -1110,6 +1110,9 @@ es:
         title: "Resumen de notificationes de propuestas"
         description: "Reune todas las notificaciones de propuestas en un único mensaje, para evitar demasiados emails."
         preview_detail: "Los usuarios sólo recibirán las notificaciones de aquellas propuestas que siguen."
+      duplicated_proposal_for_author:
+        title: "Iniciativa duplicada"
+        description: "Enviado al autor de una iniciativa cuando se marca como duplicada."
       budget_investment_created:
         title: "Proyecto de gasto creado"
         description: "Enviado cuando un usuario crea un proyecto de presupuestos participativos."
@@ -1523,6 +1526,7 @@ es:
         target: Meta
         select: Seleccionar
         selected: Seleccionada
+        duplicated: Duplicada
         no_proposals: No hay iniciativas.
         list:
             id: ID
@@ -1535,11 +1539,12 @@ es:
             target: Meta
             tags: Etiquetas
             selected: Seleccionada
-
       show:
         create_question: Añadir esta iniciativa a una votación para ser votada
       form:
         update: Actualizar iniciativa ciudadana
+        duplicated_of_proposal_description: "El autor de esta iniciativa recibirá una notificación por email. Puedes ver la plantilla del email %{link}."
+        here: "aquí"
       update:
         notice: Iniciativa actualizada correctamente
       subnav:

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -478,6 +478,10 @@ es:
       comments_tab: Comentarios
       dashboard_proposal_link: Panel de control
       flag: Esta iniciativa ha sido marcada como inapropiada por varios usuarios.
+      duplicated: Iniciativa duplicada
+      duplicated_description: Esta iniciativa ha sido marcada como duplicada de la iniciativa %{link_to_original}.
+      original: Iniciativa original
+      original_description: "Esta iniciativa es la original de las siguientes iniciativas duplicadas:"
       notifications_tab: Notificaciones
       milestones_tab: Seguimiento
       retired_warning: "El autor/a de esta iniciativa considera que ya no debe seguir recogiendo apoyos."

--- a/config/locales/custom/es/mailers.yml
+++ b/config/locales/custom/es/mailers.yml
@@ -34,6 +34,20 @@ es:
       comment: Comentar propuesta
       unsubscribe_text: "Si no quieres recibir notificaciones de propuestas, puedes entrar en %{notifications} y desmarcar la opción 'Recibir resumen de notificaciones sobre propuestas'."
       unfollow: "Si no quieres recibir más notificaciones, visita esta propuesta y deja de seguirla."
+    duplicated_proposal_for_author:
+      sample:
+        proposal:
+          title: 'TÍTULO DE TU INICIATIVA'
+          descripción: 'DESCRIPCIÓN DE TU INICIATIVA'
+        original_proposal:
+          title: 'TÍTULO DE LA INICIATIVA ORIGINAL'
+          descripción: 'DESCRIPCIÓN DE LA INICIATIVA ORIGINAL'
+      subject: "Tu iniciativa '%{proposal_title}' es muy similar a otra ya existente"
+      hi: Hola
+      explanation: "Hemos detectado que la iniciativa %{title} que has enviado es muy similar a otra que ya existe en la plataforma. Esto puede ocurrir por varias razones, como que la iniciativa haya sido duplicada por error o que el tema ya haya sido tratado anteriormente. Consideramos que la iniciativa relacionada que unificará las iniciativas similares es la siguiente:"
+      options: 'Te recomendamos revisar la iniciativa existente para ver si se ajusta a tus ideas o si puedes contribuir a ella. En este caso debes retirar tu iniciativa (a continuación te indicamos cómo hacerlo).Si crees que tu iniciativa es diferente y merece ser considerada por separado, por favor contáctanos para que podamos revisarla manualmente.'
+      action: "Para retirar tu iniciativa, haz clic en el siguiente enlace:"
+      sincerely: Agradecemos tu participación y te animamos a seguir contribuyendo con nuevas ideas y iniciativas.
     direct_message_for_receiver:
       subject: "Has recibido un nuevo mensaje privado"
       reply: Responder a %{sender}

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -253,6 +253,7 @@ val:
         responsible_name: "Nom i cognoms de la persona que fa aquesta proposta"
         retired_reason: "Razón por la que se retira la propuesta"
         selected: "Marcar como seleccionada"
+        duplicated_of_proposal_id: "Iniciativa duplicada de"
         terms_of_service: "Termes de servei"
         video_url: "Enllaç a vídeo extern"
       proposal/translation:

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -842,12 +842,59 @@ val:
         title: "Resum de Notificacions de Iniciatives"
         description: "Reuneix totes les notificacions de iniciatives en un únic missatge, per a evitar massa emails."
         preview_detail: "Els usuaris sols rebran les notificacions d'aquelles iniciatives que segueixquen"
+      duplicated_proposal_for_author:
+        title: "Iniciativa duplicada"
+        description: "Enviat a l'autor d'una iniciativa quan es marca com a duplicada."
+      budget_investment_created:
+        title: "Projecte de gasto creat"
+        description: "Enviat quan un usuari crea un projecte de pressupostos participatius."
+      budget_investment_selected:
+        title: "Projecte de gasto seleccionat"
+        description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut seleccionat."
+      budget_investment_unfeasible:
+        title: "Projecte de gasto inviable"
+        description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut marcat com a inviable."
+      budget_investment_not_selected:
+        title: "Projecte de gasto no seleccionat"
+        description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut marcat com no seleccionat en fase de revisió interna."
+      budget_investment_unselected:
+        title: "Projecte de gasto no seleccionat"
+        description: "Enviat a l'autor d'un projecte de pressupostos participatius que no ha sigut seleccionat per a la fase de votació."
       budget_investment_takecharge:
         title: "Projecte de gasto assumit"
         description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut marcat com assumit."
       budget_investment_next_year_budget:
         title: "Projecte de gasto previst per a inclusió en pressupost del pròxim any"
         description: "Enviat a l'autor d'un projecte de pressupostos participatius que ha sigut marcat com a previst per a inclusió en pressupost del pròxim any."
+      comment:
+        title: "Comentari"
+        description: "Enviat a l'autor quan rep un comentari."
+      reply:
+        title: "Resposta"
+        description: "Enviat a l'autor del comentari quan rep una resposta."
+      direct_message_for_receiver:
+        title: "Missatge privat rebut"
+        description: "Enviat al receptor d'un missatge privat."
+      direct_message_for_sender:
+        title: "Missatge privat enviat"
+        description: "Enviat al remitent d'un missatge privat."
+      email_verification:
+        title: "Verificació per email"
+        description: "Enviat al nou usuari registrat per a verificar el seu compte."
+      user_invite:
+        title: "Invitació d'usuaris"
+        description: "Enviat a la persona que ha sigut convidada a registrar un compte."
+      evaluation_comment:
+        title: "Nou comentari d'avaluació"
+        description: "Enviat a administradors i avaluadors del pressupost."
+      edit_info: "Pots editar este email en"
+      message_title: "Títol del missatge"
+      message_body: "Este és un exemple de contingut d'un missatge."
+      alert:
+        no_investments: "No s'ha creat cap projecte de gasto. Es necessita algun exemple per a poder previsualizar l'email."
+        no_comments: "No s'ha creat cap comentari. Es necessita algun exemple per a poder previsualizar l'email."
+        no_replies: "No s'ha creat cap resposta. Es necessita algun exemple per a poder previsualizar l'email."
+        no_evaluation_comments: "No s'ha creat cap comentari d'avaluació. Es necessita algun exemple per a poder previsualizar l'email."
     emails_download:
       index:
         title: Descàrrega de emails
@@ -1167,6 +1214,7 @@ val:
         target: Meta
         select: Seleccionar
         selected: Seleccionada
+        duplicated: Duplicada
         no_proposals: No hi han iniciatives.
         list:
             id: ID
@@ -1179,6 +1227,14 @@ val:
             target: Meta
             tags: Etiquetes
             selected: Seleccionada
+      show:
+        create_question: Afegir esta iniciativa a una votació per a ser votada
+      form:
+        update: Actualitzar iniciativa ciutadana
+        duplicated_of_proposal_description: "L'autor d'esta iniciativa rebrà una notificació per email. Pots veure la plantilla de l'email %{link}."
+        here: "ací"
+      update:
+        notice: Iniciativa actualitzada correctament
       subnav:
         proposals: Iniciatives
         help_text: Text d'ajuda

--- a/config/locales/custom/val/general.yml
+++ b/config/locales/custom/val/general.yml
@@ -418,7 +418,12 @@ val:
         one: 1 Comentari
         other: "%{count} Comentaris"
       comments_tab: Comentaris
+      dashboard_proposal_link: Panell de control
       flag: Esta iniciativa ha sigut marcada com inapropiada per diversos usuaris.
+      duplicated: Iniciativa duplicada
+      duplicated_description: Esta iniciativa ha sigut marcada com a duplicada de la iniciativa %{link_to_original}.
+      original: Iniciativa original
+      original_description: "Esta iniciativa és l'original de les següents iniciatives duplicades:"
       notifications_tab: Notificacions
       milestones_tab: Seguiments
       retired_warning: "L'autor/a d'esta iniciativa considera que ja no ha de seguir recollint avals."
@@ -429,6 +434,7 @@ val:
       embed_video_title: "Vídeo en %{proposal}"
       title_video_url: "Video extern"
       author: Autor/a
+      draft: Iniciativa en esborrany. Encara no pot arreplegar suports, ni apareix en la llista d'iniciatives.
     update:
       form:
         submit_button: Guardar canvis

--- a/config/locales/custom/val/mailers.yml
+++ b/config/locales/custom/val/mailers.yml
@@ -24,6 +24,22 @@ val:
       title: "Notificacions de propostes en %{org_name}"
       share: Compartir proposta
       comment: Comentar proposta
+      unsubscribe_text: "Si no vols rebre notificacions de propostes, pots entrar en %{notifications} i desmarcar l'opció 'Rebre resum de notificacions sobre propostes'."
+      unfollow: "Si no vols rebre més notificacions, visita esta proposta i deixa de seguir-la."
+    duplicated_proposal_for_author:
+      sample:
+        proposal:
+          title: 'TÍTOL DE LA TEUA INICIATIVA'
+          descripción: 'DESCRIPCIÓ DEL TEU INICIATIVA'
+        original_proposal:
+          title: 'TÍTOL DE LA INICIATIVA ORIGINAL'
+          descripción: 'DESCRIPCIÓ DE LA INICIATIVA ORIGINAL'
+      subject: "La teua iniciativa '%{*proposal_*title}' és molt similar a una altra ja existent"
+      hi: Hola
+      explanation: "Hem detectat que la iniciativa %{*title} que has enviat és molt similar a una altra que ja existix en la plataforma. Això pot ocórrer per diverses raons, com que la iniciativa haja sigut duplicada per error o que el tema ja haja sigut tractat anteriorment. Considerem que la iniciativa relacionada que unificarà les iniciatives similars és la següent:"
+      options: "Et recomanem revisar la iniciativa existent per a veure si s'ajusta a les teues idees o si pots contribuir a ella. En este cas has de retirar la teua iniciativa (a continuació t'indiquem com fer-ho).Si creus que la teua iniciativa és diferent i mereix ser considerada per separat, per favor contacta'ns perquè puguem revisar-la manualment."
+      action: "Per a retirar la teua iniciativa, fes clic en el següent enllaç:"
+      sincerely: Agraïm la teua participació i t'animem a continuar contribuint amb noves idees i iniciatives.
     direct_message_for_receiver:
       subject: "Has rebut un missatge privat"
       reply: Respondre a %{sender}

--- a/db/migrate/20250924163000_add_duplicated_of_proposal_to_proposals.rb
+++ b/db/migrate/20250924163000_add_duplicated_of_proposal_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddDuplicatedOfProposalToProposals < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :proposals, :duplicated_of_proposal, foreign_key: { to_table: :proposals }, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_16_130000) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_24_163000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -1412,11 +1412,13 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_16_130000) do
     t.integer "community_id"
     t.datetime "published_at", precision: nil
     t.boolean "selected", default: false
+    t.bigint "duplicated_of_proposal_id"
     t.index ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at"
     t.index ["author_id"], name: "index_proposals_on_author_id"
     t.index ["cached_votes_up"], name: "index_proposals_on_cached_votes_up"
     t.index ["community_id"], name: "index_proposals_on_community_id"
     t.index ["confidence_score"], name: "index_proposals_on_confidence_score"
+    t.index ["duplicated_of_proposal_id"], name: "index_proposals_on_duplicated_of_proposal_id"
     t.index ["geozone_id"], name: "index_proposals_on_geozone_id"
     t.index ["hidden_at"], name: "index_proposals_on_hidden_at"
     t.index ["hot_score"], name: "index_proposals_on_hot_score"
@@ -1964,6 +1966,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_16_130000) do
   add_foreign_key "poll_voters", "polls"
   add_foreign_key "polls", "budgets"
   add_foreign_key "proposals", "communities"
+  add_foreign_key "proposals", "proposals", column: "duplicated_of_proposal_id"
   add_foreign_key "related_content_scores", "related_contents"
   add_foreign_key "related_content_scores", "users"
   add_foreign_key "sdg_managers", "users"


### PR DESCRIPTION
## Objectives

> Admins can mark a proposal as duplicated of other one. A mail is sent to the author of the proposal, explaining the retired method.

## Visual Changes

> <img width="944" height="901" alt="image" src="https://github.com/user-attachments/assets/786cade4-68aa-4ddd-993f-0aae9067c52e" />

> <img width="952" height="988" alt="image" src="https://github.com/user-attachments/assets/7b781c0b-724d-4563-9de4-7ef96760cd73" />
