### PR TITLE
Issue/8408 buzón de la ciudadanía

### DIFF
--- a/app/components/custom/admin/menu_component.rb
+++ b/app/components/custom/admin/menu_component.rb
@@ -38,7 +38,7 @@ class Admin::MenuComponent
     end
 
     def messages_sections
-      %w[bulletins newsletters emails_download admin_notifications system_emails]
+      %w[bulletins newsletters admin_notifications system_emails emails_download citizen_opinions]
     end
 
     def key_systems_link
@@ -126,6 +126,14 @@ class Admin::MenuComponent
       ]
     end
 
+    def citizenship_mailbox_link
+      [
+        t("admin.menu.citizenship_mailbox"),
+        admin_citizen_opinions_path,
+        controller_name == "citizen_opinions"
+      ]
+    end
+
     def messages_links
       section(t("admin.menu.messaging_users"), active: messages_menu_active?, class: "messages-link") do
         link_list(
@@ -134,6 +142,7 @@ class Admin::MenuComponent
           admin_notifications_link,
           system_emails_link,
           emails_download_link,
+          citizenship_mailbox_link,
           id: "messaging_users_menu"
         )
       end

--- a/app/controllers/custom/admin/citizen_opinions_controller.rb
+++ b/app/controllers/custom/admin/citizen_opinions_controller.rb
@@ -1,0 +1,7 @@
+class Admin::CitizenOpinionsController < Admin::BaseController
+  load_and_authorize_resource
+
+  def index
+    @citizen_opinions = CitizenOpinion.page(params[:page])
+  end
+end

--- a/app/controllers/custom/citizen_opinions_controller.rb
+++ b/app/controllers/custom/citizen_opinions_controller.rb
@@ -1,13 +1,13 @@
 class CitizenOpinionsController < ApplicationController
   skip_authorization_check
-  
+
   def new
     @citizen_opinion = CitizenOpinion.new
   end
 
   def create
     @citizen_opinion = CitizenOpinion.new(citizen_opinion_params)
-    
+
     if @citizen_opinion.save
       CitizenOpinionMailer.notification(@citizen_opinion).deliver_later
       CitizenOpinionMailer.confirmation(@citizen_opinion).deliver_later
@@ -20,14 +20,14 @@ class CitizenOpinionsController < ApplicationController
 
   private
 
-  def citizen_opinion_params
-    params.require(:citizen_opinion).permit(
-      :topic, 
-      :name,
-      :phone, 
-      :subject,
-      :body,
-      :email
-    )
-  end
+    def citizen_opinion_params
+      params.require(:citizen_opinion).permit(
+        :topic,
+        :name,
+        :phone,
+        :subject,
+        :body,
+        :email
+      )
+    end
 end

--- a/app/controllers/custom/citizen_opinions_controller.rb
+++ b/app/controllers/custom/citizen_opinions_controller.rb
@@ -1,0 +1,33 @@
+class CitizenOpinionsController < ApplicationController
+  skip_authorization_check
+  
+  def new
+    @citizen_opinion = CitizenOpinion.new
+  end
+
+  def create
+    @citizen_opinion = CitizenOpinion.new(citizen_opinion_params)
+    
+    if @citizen_opinion.save
+      CitizenOpinionMailer.notification(@citizen_opinion).deliver_later
+      CitizenOpinionMailer.confirmation(@citizen_opinion).deliver_later
+      flash[:notice] = t("citizen_opinions.success.title")
+      redirect_to new_citizen_opinion_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def citizen_opinion_params
+    params.require(:citizen_opinion).permit(
+      :topic, 
+      :name,
+      :phone, 
+      :subject,
+      :body,
+      :email
+    )
+  end
+end

--- a/app/helpers/custom/citizen_opinions_helper.rb
+++ b/app/helpers/custom/citizen_opinions_helper.rb
@@ -1,0 +1,25 @@
+module Custom::CitizenOpinionsHelper
+  def topics_options
+    TOPIC_GROUPS.map do |group_key, topics|
+      [
+        t("citizen_opinions.form.topic.groups.#{group_key}"),
+        topics.map { |topic_key| [t("citizen_opinions.form.topic.options.#{topic_key}"), "#{topic_key}"] }
+      ]
+    end
+  end
+
+  private
+
+    TOPIC_GROUPS = {
+      general: [:suggestions, :public_employment, :others],
+      social_services: [:dependency, :disability, :large_families, :childhood, :inclusion_income, :other_social_services, :housing_rental, :housing_purchase, :subsidized_housing, :housing_registry, :housing_renovation],
+      treasury: [:economy, :taxes],
+      justice: [:associations, :legal_aid, :common_law_marriages, :other_justice_issues, :civil_registry_Alcoy, :civil_registry_Alzira, :civil_registry_Benidorm, :civil_registry_Carlet, :civil_registry_Castello, :civil_registry_Catarroja, :civil_registry_Dénia, :civil_registry_Elda, :civil_registry_Elche, :civil_registry_Gandia, :civil_registry_Ibi, :civil_registry_Villajoyosa, :civil_registry_Lliria, :civil_registry_Massamagrell, :civil_registry_Mislata, :civil_registry_Moncada, :civil_registry_Novelda, :civil_registry_Nules, :civil_registry_Ontinyent, :civil_registry_Orihuela, :civil_registry_Paterna, :civil_registry_Picassent, :civil_registry_Quart, :civil_registry_Requena, :civil_registry_Sagunto, :civil_registry_San_Vicente, :civil_registry_Segorbe, :civil_registry_Sueca, :civil_registry_Torrent, :civil_registry_Torrevieja, :civil_registry_Vila_real, :civil_registry_Villena, :civil_registry_Vinaros, :civil_registry_Xativa, :exclusive_civil_registry_1_Alicante, :exclusive_civil_registry_1_Valencia, :exclusive_civil_registry_2_Alicante, :exclusive_civil_registry_2_Valencia, :exclusive_civil_registry_3_Valencia],
+      health: [:healthcare],
+      education: [:education, :valencian, :social_economy, :work, :employment, :culture,],
+      environment: [:airports, :nautical_activities, :coasts, :roads, :ports, :transport, :urban_planning, :territorial_policy, :environment],
+      innovation: [:trade, :industry, :innovation, :AVI, :IVACE, :tourism],
+      agriculture: [:agriculture],
+      emergency: [:forest_fire_prevention, :entertainment]
+    }.freeze
+end

--- a/app/helpers/custom/citizen_opinions_helper.rb
+++ b/app/helpers/custom/citizen_opinions_helper.rb
@@ -3,7 +3,7 @@ module Custom::CitizenOpinionsHelper
     TOPIC_GROUPS.map do |group_key, topics|
       [
         t("citizen_opinions.form.topic.groups.#{group_key}"),
-        topics.map { |topic_key| [t("citizen_opinions.form.topic.options.#{topic_key}"), "#{topic_key}"] }
+        topics.map { |topic_key| [t("citizen_opinions.form.topic.options.#{topic_key}"), topic_key.to_s] }
       ]
     end
   end
@@ -12,12 +12,29 @@ module Custom::CitizenOpinionsHelper
 
     TOPIC_GROUPS = {
       general: [:suggestions, :public_employment, :others],
-      social_services: [:dependency, :disability, :large_families, :childhood, :inclusion_income, :other_social_services, :housing_rental, :housing_purchase, :subsidized_housing, :housing_registry, :housing_renovation],
+      social_services: [:dependency, :disability, :large_families, :childhood, :inclusion_income,
+                        :other_social_services, :housing_rental, :housing_purchase, :subsidized_housing,
+                        :housing_registry, :housing_renovation],
       treasury: [:economy, :taxes],
-      justice: [:associations, :legal_aid, :common_law_marriages, :other_justice_issues, :civil_registry_Alcoy, :civil_registry_Alzira, :civil_registry_Benidorm, :civil_registry_Carlet, :civil_registry_Castello, :civil_registry_Catarroja, :civil_registry_Dénia, :civil_registry_Elda, :civil_registry_Elche, :civil_registry_Gandia, :civil_registry_Ibi, :civil_registry_Villajoyosa, :civil_registry_Lliria, :civil_registry_Massamagrell, :civil_registry_Mislata, :civil_registry_Moncada, :civil_registry_Novelda, :civil_registry_Nules, :civil_registry_Ontinyent, :civil_registry_Orihuela, :civil_registry_Paterna, :civil_registry_Picassent, :civil_registry_Quart, :civil_registry_Requena, :civil_registry_Sagunto, :civil_registry_San_Vicente, :civil_registry_Segorbe, :civil_registry_Sueca, :civil_registry_Torrent, :civil_registry_Torrevieja, :civil_registry_Vila_real, :civil_registry_Villena, :civil_registry_Vinaros, :civil_registry_Xativa, :exclusive_civil_registry_1_Alicante, :exclusive_civil_registry_1_Valencia, :exclusive_civil_registry_2_Alicante, :exclusive_civil_registry_2_Valencia, :exclusive_civil_registry_3_Valencia],
+      justice: [:associations, :legal_aid, :common_law_marriages, :other_justice_issues,
+                :civil_registry_Alcoy, :civil_registry_Alzira, :civil_registry_Benidorm,
+                :civil_registry_Carlet, :civil_registry_Castello, :civil_registry_Catarroja,
+                :civil_registry_Dénia, :civil_registry_Elda, :civil_registry_Elche,
+                :civil_registry_Gandia, :civil_registry_Ibi, :civil_registry_Villajoyosa,
+                :civil_registry_Lliria, :civil_registry_Massamagrell, :civil_registry_Mislata,
+                :civil_registry_Moncada, :civil_registry_Novelda, :civil_registry_Nules,
+                :civil_registry_Ontinyent, :civil_registry_Orihuela, :civil_registry_Paterna,
+                :civil_registry_Picassent, :civil_registry_Quart, :civil_registry_Requena,
+                :civil_registry_Sagunto, :civil_registry_San_Vicente, :civil_registry_Segorbe,
+                :civil_registry_Sueca, :civil_registry_Torrent, :civil_registry_Torrevieja,
+                :civil_registry_Vila_real, :civil_registry_Villena, :civil_registry_Vinaros,
+                :civil_registry_Xativa, :exclusive_civil_registry_1_Alicante,
+                :exclusive_civil_registry_1_Valencia, :exclusive_civil_registry_2_Alicante,
+                :exclusive_civil_registry_2_Valencia, :exclusive_civil_registry_3_Valencia],
       health: [:healthcare],
-      education: [:education, :valencian, :social_economy, :work, :employment, :culture,],
-      environment: [:airports, :nautical_activities, :coasts, :roads, :ports, :transport, :urban_planning, :territorial_policy, :environment],
+      education: [:education, :valencian, :social_economy, :work, :employment, :culture],
+      environment: [:airports, :nautical_activities, :coasts, :roads, :ports, :transport,
+                    :urban_planning, :territorial_policy, :environment],
       innovation: [:trade, :industry, :innovation, :AVI, :IVACE, :tourism],
       agriculture: [:agriculture],
       emergency: [:forest_fire_prevention, :entertainment]

--- a/app/mailers/custom/citizen_opinion_mailer.rb
+++ b/app/mailers/custom/citizen_opinion_mailer.rb
@@ -1,0 +1,15 @@
+class CitizenOpinionMailer < ApplicationMailer
+  NOTIFICATION_RECIPIENT = Rails.application.secrets.citizen_opinions_mail_recipient
+
+  def notification(citizen_opinion)
+    @citizen_opinion = citizen_opinion
+    mail(to: NOTIFICATION_RECIPIENT,
+         subject: t("citizen_opinion_mailer.notification.subject", topic: t("citizen_opinions.form.topic.options.#{citizen_opinion.topic}")))
+  end
+
+  def confirmation(citizen_opinion)
+    @citizen_opinion = citizen_opinion
+    mail(to: citizen_opinion.email,
+         subject: t("citizen_opinion_mailer.confirmation.subject"))
+  end
+end

--- a/app/mailers/custom/citizen_opinion_mailer.rb
+++ b/app/mailers/custom/citizen_opinion_mailer.rb
@@ -4,7 +4,8 @@ class CitizenOpinionMailer < ApplicationMailer
   def notification(citizen_opinion)
     @citizen_opinion = citizen_opinion
     mail(to: NOTIFICATION_RECIPIENT,
-         subject: t("citizen_opinion_mailer.notification.subject", topic: t("citizen_opinions.form.topic.options.#{citizen_opinion.topic}")))
+         subject: t("citizen_opinion_mailer.notification.subject",
+                    topic: t("citizen_opinions.form.topic.options.#{citizen_opinion.topic}")))
   end
 
   def confirmation(citizen_opinion)

--- a/app/models/custom/ability.rb
+++ b/app/models/custom/ability.rb
@@ -18,10 +18,10 @@ class Ability
         can [:manage], ::BudgetManager
         can [:manage], ::Bulletin
         can [:manage], ::Legislation::Council
+        can [:manage], ::CitizenOpinion
       elsif user.supporter?
         merge Abilities::Supporter.new(user)
         can [:manage], ::Legislator
-
       elsif user.legislator?
         merge Abilities::Legislator.new(user)
       elsif user.budget_manager?

--- a/app/models/custom/citizen_opinion.rb
+++ b/app/models/custom/citizen_opinion.rb
@@ -1,0 +1,8 @@
+class CitizenOpinion < ApplicationRecord
+  paginates_per 25
+
+  validates :topic, presence: true
+  validates :body, presence: true  
+  EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\z/
+  validates :email, presence: true, format: { with: EMAIL_REGEX }
+end

--- a/app/models/custom/citizen_opinion.rb
+++ b/app/models/custom/citizen_opinion.rb
@@ -2,7 +2,7 @@ class CitizenOpinion < ApplicationRecord
   paginates_per 25
 
   validates :topic, presence: true
-  validates :body, presence: true  
+  validates :body, presence: true
   EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\z/
   validates :email, presence: true, format: { with: EMAIL_REGEX }
 end

--- a/app/views/custom/admin/citizen_opinions/index.html.erb
+++ b/app/views/custom/admin/citizen_opinions/index.html.erb
@@ -1,0 +1,40 @@
+<% provide(:title) do %>
+  <%= t("admin.header.title") %> - <%= t("admin.citizen_opinions.index.title") %>
+<% end %>
+
+<h2><%= t("admin.citizen_opinions.index.title") %></h2>
+
+<% if @citizen_opinions.any? %>
+  <h3><%= page_entries_info @citizen_opinions %></h3>
+  <table>
+    <thead>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :created_at %></th>
+      <th class="text-right"><%= link_to_sorted_admin_resource "citizen_opinions", :id %></th>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :topic %></th>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :name %></th>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :subject %></th>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :body %></th>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :phone %></th>
+      <th><%= link_to_sorted_admin_resource "citizen_opinions", :email %></th>
+    </thead>
+    <tbody>
+      <% @citizen_opinions.each do |citizen_opinion| %>
+        <tr id="<%= dom_id(citizen_opinion) %>" class="citizen_opinions">
+          <td><%= I18n.l citizen_opinion.created_at, format: :short %></td>
+          <td class="text-right"><%= citizen_opinion.id %></td>
+          <td><%= t("citizen_opinions.form.topic.options.#{citizen_opinion.topic}") %></td>
+          <td><%= citizen_opinion.name %></td>
+          <td><%= citizen_opinion.subject %></td>
+          <td><%= citizen_opinion.body %></td>
+          <td><%= citizen_opinion.phone %></td>
+          <td><%= citizen_opinion.email %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= paginate @citizen_opinions %>
+<% else %>
+  <div class="callout primary margin column">
+    <%= t("admin.citizen_opinions.index.no_citizen_opinions") %>
+  </div>
+<% end %>

--- a/app/views/custom/citizen_opinion_mailer/confirmation.html.erb
+++ b/app/views/custom/citizen_opinion_mailer/confirmation.html.erb
@@ -1,0 +1,12 @@
+<h1><%= t("citizen_opinion_mailer.confirmation.title") %></h1>
+<p><%= t("citizen_opinion_mailer.confirmation.text") %></p>
+
+<p><strong><%= t("citizen_opinion_mailer.shared.date") %>:</strong> <%= I18n.l @citizen_opinion.created_at, format: :short %></p>
+<p><strong><%= t("citizen_opinion_mailer.confirmation.name") %>:</strong> <%= @citizen_opinion.name %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.phone") %>:</strong> <%= @citizen_opinion.phone %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.email") %>:</strong> <%= @citizen_opinion.email %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.topic") %>:</strong> <%= t("citizen_opinions.form.topic.options.#{@citizen_opinion.topic}") %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.subject") %>:</strong> <%= @citizen_opinion.subject %></p>
+
+<h2><%= t("citizen_opinion_mailer.shared.body") %>:</h2>
+<p><%= simple_format @citizen_opinion.body %></p>

--- a/app/views/custom/citizen_opinion_mailer/notification.html.erb
+++ b/app/views/custom/citizen_opinion_mailer/notification.html.erb
@@ -1,0 +1,12 @@
+<h1><%= t("citizen_opinion_mailer.notification.title") %></h1>
+<p><%= t("citizen_opinion_mailer.notification.text") %></p>
+
+<p><strong><%= t("citizen_opinion_mailer.shared.date") %>:</strong> <%= I18n.l @citizen_opinion.created_at, format: :short %></p>
+<p><strong><%= t("citizen_opinion_mailer.notification.from") %>:</strong> <%= @citizen_opinion.name %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.phone") %>:</strong> <%= @citizen_opinion.phone %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.email") %>:</strong> <%= @citizen_opinion.email %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.topic") %>:</strong> <%= t("citizen_opinions.form.topic.options.#{@citizen_opinion.topic}") %></p>
+<p><strong><%= t("citizen_opinion_mailer.shared.subject") %>:</strong> <%= @citizen_opinion.subject %></p>
+
+<h2><%= t("citizen_opinion_mailer.shared.body") %>:</h2>
+<p><%= simple_format @citizen_opinion.body %></p>

--- a/app/views/custom/citizen_opinions/_form.html.erb
+++ b/app/views/custom/citizen_opinions/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_for @citizen_opinion, url: citizen_opinions_path, html: { novalidate: true } do |f| %>
+  <div class="row">
+    <div class="small-12 column">
+      <%= f.select :topic,
+                   grouped_options_for_select(topics_options),
+                   { prompt: t("citizen_opinions.form.topic.prompt") },
+                   { required: true, class: "form-control" } %>
+    </div>
+
+    <div class="small-12 medium-6 column">
+      <%= f.text_field :name %>
+    </div>
+
+    <div class="small-12 medium-6 column">
+      <%= f.text_field :phone %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.text_field :subject %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.text_area :body, rows: 5, required: true %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.email_field :email, required: true %>
+    </div>
+  </div>
+
+  <div class="small-12 column text-center">
+    <%= f.submit t("citizen_opinions.form.submit"), class: "button" %>
+  </div>
+<% end %>

--- a/app/views/custom/citizen_opinions/new.html.erb
+++ b/app/views/custom/citizen_opinions/new.html.erb
@@ -1,0 +1,15 @@
+<% provide :title do %><%= t("citizen_opinions.new.title") %><% end %>
+<h2><%= t("citizen_opinions.new.title") %></h2>
+
+<%= render "form" %>
+
+<div class="row margin">
+  <h3><%= t("citizen_opinions.new.processing_personal_data") %></h3>
+  <div>
+  <%= t("citizen_opinions.new.processing_personal_data_description") %>
+  </div>
+  <div>
+    <a href='<%= t("citizen_opinions.new.data_protection_link") %>' target='_blank' rel='noopener'>
+    <%= t("citizen_opinions.new.basic_information_on_data_protection") %>
+  </div>
+</div>

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -158,6 +158,9 @@ es:
       alert_message:
         one: Mensaje de alerta
         other: Mensajes de alerta
+      citizen_opinion:
+        one: Opinión del ciudadano
+        other: Opiniones del ciudadano
     attributes:
       administrator:
         description: Descripción
@@ -578,6 +581,13 @@ es:
         document_number: Número de documento
         date_of_birth: Fecha de nacimiento
         postal_code: Código postal
+      citizen_opinion:
+        topic: Tema de la consulta
+        name: Nombre
+        phone: Teléfono
+        subject: Asunto
+        body: Pregunta o Sugerencia
+        email: Correo electrónico de respuesta
     errors:
       models:
         user:
@@ -667,6 +677,15 @@ es:
           attributes:
             code:
               invalid: "debe empezar con el código de su meta seguido de un punto y terminar con un número"
+        citizen_opinion:
+          attributes:
+            topic:
+              blank: "Por favor, seleccione un tema de la lista"
+            body:
+              blank: "No puede estar en blanco"
+            email:
+              blank: "No puede estar en blanco"
+              invalid: "No es un formato de email válido"
       messages:
         translations_too_short: El obligatorio proporcionar una traducción como mínimo
         record_invalid: "Error de validación: %{errors}"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -903,6 +903,7 @@ es:
       admin_notifications: Notificaciones
       system_emails: Emails del sistema
       emails_download: Descarga de emails
+      citizenship_mailbox: Buzón de la ciudadanía
       valuators: Evaluadores
       poll_officers: Presidentes de mesa
       polls: Votaciones
@@ -1169,6 +1170,19 @@ es:
         download_segment: Descargar direcciones de correo electrónico
         download_segment_help_text: Descarga en formato CSV
         download_emails_button: Descargar lista de emails
+    citizen_opinions:
+      index:
+        title: Buzón de la ciudadanía
+        no_citizen_opinions: No hay mensajes en el buzón de la ciudadanía
+        list:
+          id: ID
+          topic: Tema
+          name: Nombre
+          subject: Asunto
+          body: Mensaje
+          phone: Teléfono
+          email: Email
+          created_at: Fecha de envío
     valuators:
       index:
         title: Evaluadores

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -332,6 +332,116 @@ es:
       sign_in: "Entra con:"
       sign_up: "Regístrate con:"
     or_fill: "O rellena el siguiente formulario:"
+  citizen_opinions:
+    new:
+      title: "Mi opinión cuenta"
+      processing_personal_data: Tratamiento de datos de carácter personal
+      processing_personal_data_description: Se informa que la Generalitat llevará a término el tratamiento de sus datos personals de acuerdo con el Reglamento General de Protección de Datos (UE) 2016/679 y la Ley Orgánica 3/2018 de Protección de Datos y garantía de los derechos digitales.
+      basic_information_on_data_protection: Información básica sobre protección de datos
+      data_protection_link: https://www.gva.es/es/web/atencio_ciutadania/inicio/mi_opinion_cuenta/informacio-basica-sobre-proteccio-de-dades
+    form:
+      topic:
+        label: "Tema de la consulta"
+        prompt: "Seleccione una opción"
+        groups:
+          general: "General"
+          social_services: "Vicepresidencia primera y Conselleria de Servicios Sociales, Igualdad y Vivienda" 
+          treasury: "Conselleria de Hacienda y Economía"
+          justice: "Conselleria de Justicia y Administración Pública"
+          health: "Conselleria de Sanidad"
+          education: "Conselleria de Educación, Cultura, Universidades y Empleo"
+          environment: "Conselleria de Medio Ambiente, Infraestructuras y Territorio"
+          innovation: "Conselleria de Innovación, Industria, Comercio y Turismo"
+          agriculture: "Consellería de Agricultura, Agua, Ganadería y Pesca"
+          emergency: "Conselleria de Emergencias e Interior"
+        options:
+          suggestions: Sugerencias, iniciativas y agradecimientos
+          public_employment: Empleo público
+          others: Otros temas
+          dependency: Dependencia
+          disability: Discapacidad / Diversidad funcional
+          large_families: Familia numerosa / monoparental
+          childhood: Infancia y adolescencia
+          inclusion_income: Renta valenciana de inclusión
+          other_social_services: Otros temas de servicios sociales
+          housing_rental: Alquiler vivienda
+          housing_purchase: Compra vivienda
+          subsidized_housing: Promoción vivienda protegida
+          housing_registry: Registro valenciano de la vivienda
+          housing_renovation: Rehabilitación vivienda
+          economy: Economía
+          taxes: Impuestos y transmisiones
+          associations: Asociaciones
+          legal_aid: Justicia gratuita
+          common_law_marriages: Uniones de hecho
+          other_justice_issues: Otros temas de justicia y administración
+          civil_registry_Alcoy: Registro Civil de Alcoy/Alcoy
+          civil_registry_Alzira: Registro Civil de Alzira
+          civil_registry_Benidorm: Registro Civil de Benidorm
+          civil_registry_Carlet: Registro Civil de Carlet
+          civil_registry_Castello: Registro Civil de Castelló de la Plana
+          civil_registry_Catarroja: Registro Civil de Catarroja
+          civil_registry_Dénia: Registro Civil de Dénia
+          civil_registry_Elda: Registro Civil de Elda
+          civil_registry_Elche: Registro Civil de Elche/Elche
+          civil_registry_Gandia: Registro Civil de Gandia
+          civil_registry_Ibi: Registro Civil de Ibi
+          civil_registry_Villajoyosa: Registro Civil de Villajoyosa
+          civil_registry_Lliria: Registro Civil de Llíria
+          civil_registry_Massamagrell: Registro Civil de Massamagrell
+          civil_registry_Mislata: Registro Civil de Mislata
+          civil_registry_Moncada: Registro Civil de Moncada
+          civil_registry_Novelda: Registro Civil de Novelda
+          civil_registry_Nules: Registro Civil de Nules
+          civil_registry_Ontinyent: Registro Civil de Ontinyent
+          civil_registry_Orihuela: Registro Civil de Orihuela
+          civil_registry_Paterna: Registro Civil de Paterna
+          civil_registry_Picassent: Registro Civil de Picassent
+          civil_registry_Quart: Registro Civil de Quart de Poblet
+          civil_registry_Requena: Registro Civil de Requena
+          civil_registry_Sagunto: Registro Civil de Sagunto
+          civil_registry_San_Vicente: Registro Civil de San Vicente del Raspeig
+          civil_registry_Segorbe: Registro Civil de Segorbe
+          civil_registry_Sueca: Registro Civil de Sueca
+          civil_registry_Torrent: Registro Civil de Torrent
+          civil_registry_Torrevieja: Registro Civil de Torrevieja
+          civil_registry_Vila_real: Registro Civil de Vila-real
+          civil_registry_Villena: Registro Civil de Villena
+          civil_registry_Vinaros: Registro Civil de Vinaròs
+          civil_registry_Xativa: Registro Civil de Xàtiva
+          exclusive_civil_registry_1_Alicante: Registro Civil Exclusivo Nº1 Alicante
+          exclusive_civil_registry_1_Valencia: Registro Civil Exclusivo Nº1 Valencia
+          exclusive_civil_registry_2_Alicante: Registro Civil Exclusivo Nº2 Alicante
+          exclusive_civil_registry_2_Valencia: Registro Civil Exclusivo Nº2 Valencia
+          exclusive_civil_registry_3_Valencia: Registro Civil Exclusivo Nº3 Valencia
+          healthcare: Sanidad
+          education: Enseñanza
+          valencian: Valenciano (Junta Calificadora)
+          social_economy: Economía social / Cooperativas
+          work: Trabajo
+          employment: Ocupación (LABORA)
+          culture: Cultura
+          airports: Aeropuertos
+          nautical_activities: Actividades náuticas (exámenes / titulaciones)
+          coasts: Costas
+          roads: Carreteras
+          ports: Puertos
+          transport: Transportes (Exámenes transportistas / tarjetas transportes ...)
+          urban_planning: Urbanismo
+          territorial_policy: Política territorial y paisaje
+          environment: Medio ambiente
+          trade: Comercio y consumo
+          industry: Industria, energía y minas
+          innovation: Innovación
+          AVI: AVI (Agencia Valenciana de la Innovación)
+          IVACE: IVACE (Instituto Valenciano de Competitividad Empresarial)
+          tourism: Turismo (Turismo Comunidad Valenciana)
+          agriculture: Agricultura, agua, ganadería y pesca
+          forest_fire_prevention: Prevención de incendios forestales
+          entertainment: Espectáculos
+      submit: "Enviar"
+    success:
+      title: "¡Gracias por su colaboración! Recibirá un email con una copia de su mensaje."
   proposals:
     create:
       form:

--- a/config/locales/custom/es/mailers.yml
+++ b/config/locales/custom/es/mailers.yml
@@ -185,3 +185,22 @@ es:
       text_9: "También encontrarás esta nueva acción de difusión recomendada…"
       text_10: "¡Seguro que tienes más recursos pendientes de usar!"
       dashboard_button: "Adelante, ¡descúbrelos!"
+  citizen_opinion_mailer:
+    shared:
+      date: "Fecha"
+      body: "Pregunta o sugerencia"
+      phone: "Teléfono"
+      email: "Correo electrónico de respuesta"
+      topic: "Tema"
+      subject: "Asunto"
+    confirmation:
+      subject: "Buzón de consultas para el PROP"
+      title: "Confirmación de envío del formulario."
+      text: "Gracias por escribirnos. Hemos recibido su mensaje."
+      name: "Nombre"
+    notification:
+      subject: "Nuevo mensaje en buzón de la ciudadanía sobre TEMA: %{topic}"
+      title: "Nuevo mensaje en buzón de la ciudadanía"
+      text: "Se ha recibido un nuevo mensaje en el buzón de la ciudadanía con el siguiente contenido:"
+      from: "De"
+      citizen_mailbox: "buzón de la ciudadanía"

--- a/config/locales/custom/val/activerecord.yml
+++ b/config/locales/custom/val/activerecord.yml
@@ -141,6 +141,9 @@ val:
       alert_message:
         one: Missatge d'alerta
         other: Missatges d'alerta
+      citizen_opinion:
+        one: Opinió del ciutadà
+        other: Opinions del ciutadà
     attributes:
       administrator:
         description: Descripción
@@ -521,6 +524,13 @@ val:
         document_number: Número de documento
         date_of_birth: Fecha de nacimiento
         postal_code: Códi postal
+      citizen_opinion:
+        topic: Tema de la consulta
+        name: Nom
+        phone: Telèfon
+        subject: Assumpte
+        body: Pregunta o Suggeriment
+        email: Correu electrònic de resposta
     errors:
       models:
         user:
@@ -610,6 +620,15 @@ val:
           attributes:
             locale:
               already_translated: Recurso ya traducido
+        citizen_opinion:
+          attributes:
+            topic:
+              blank: "Per favor, seleccione un tema de la llista"
+            body:
+              blank: "No pot estar en blanc"
+            email:
+              blank: "No pot estar en blanc"
+              invalid: "No és un format d'email vàlid"
       messages:
         translations_too_short: El obligatorio proporcionar una traducción como mínimo
         record_invalid: "Error de validación: %{errors}"

--- a/config/locales/custom/val/admin.yml
+++ b/config/locales/custom/val/admin.yml
@@ -641,6 +641,7 @@ val:
       admin_notifications: Notificacions
       system_emails: Correus electònics del sistema
       emails_download: Descàrrega de emails
+      citizenship_mailbox: Bústia de la ciutadania
       valuators: Avaluadors
       poll_officers: Presidents de taula
       polls: Votacions
@@ -901,6 +902,19 @@ val:
         download_segment: Descarregar direccions de email
         download_segment_help_text: Descarrega en format CSV
         download_emails_button: Descarregar llista de emails
+    citizen_opinions:
+      index:
+        title: Bústia de la ciutadania
+        no_citizen_opinions: No hi ha missatges en la bústia de la ciutadania
+        list:
+          id: ID
+          topic: Tema
+          name: Nom
+          subject: Assumpte
+          body: Missatge
+          phone: Telèfon
+          email: Email
+          created_at: Data d'enviament
     valuators:
       index:
         title: Avaluadors

--- a/config/locales/custom/val/general.yml
+++ b/config/locales/custom/val/general.yml
@@ -279,6 +279,116 @@ val:
       sign_up: Regístrat amb Twitter
       name: Twitter
     or_fill: "O ompli el següent formulari:"
+  citizen_opinions:
+    new:
+      title: "La meua opinió compta"
+      processing_personal_data: Tractament de dades de caràcter personal
+      processing_personal_data_description: S'informa que la Generalitat durà a terme el tractament de les seues dades personals d'acord amb el Reglament General de Protecció de Dades (UE) 2016/679 i la Llei Orgànica 3/2018 de Protecció de Dades i garantia dels drets digitals.
+      basic_information_on_data_protection: Informació bàsica sobre protecció de dades
+      data_protection_link: https://www.gva.es/va/web/atencio_ciutadania/inicio/mi_opinion_cuenta/informacio-basica-sobre-proteccio-de-dades
+    form:
+      topic:
+        label: "Tema de la consulta"
+        prompt: "Seleccioneu una opció"
+        groups:
+          general: "General"
+          social_services: "Vicepresidència primera i Conselleria de Servicis Socials, Igualtat i Vivenda" 
+          treasury: "Conselleria d'Hisenda i Economia"
+          justice: "Conselleria de Justícia i Administració Pública"
+          health: "Conselleria de Sanitat"
+          education: "Conselleria d'Educació, Cultura, Universitats i Ocupació"
+          environment: "Conselleria de Medi Ambient, Infraestructures i Territori"
+          innovation: "Conselleria d'Innovació, Indústria, Comerç i Turisme"
+          agriculture: "Conselleria d'Agricultura, Aigua, Ramaderia i Pesca"
+          emergency: "Conselleria d'Emergències i Interior"
+        options:
+          suggestions: Suggeriments, iniciatives i agraïments
+          public_employment: Ocupació pública
+          others: Altres temes
+          dependency: Dependència
+          disability: Discapacitat / Diversitat funcional
+          large_families: Família nombrosa / monoparental
+          childhood: Infància i adolescència
+          inclusion_income: Renda valenciana d'inclusió
+          other_social_services: Altres temes de serveis socials
+          housing_rental: Lloguer habitatge
+          housing_purchase: Compra habitatge
+          subsidized_housing: Promoció habitatge protegit
+          housing_registry: Registre valencià de l'habitatge
+          housing_renovation: Rehabilitació habitatge
+          economy: Economia
+          taxes: Impostos i transmissions
+          associations: Associacions
+          legal_aid: Justícia gratuïta
+          common_law_marriages: Unions de fet
+          other_justice_issues: Altres temes de justícia i administració pública
+          civil_registry_Alcoy: Registre Civil d'Alcoi/Alcoy
+          civil_registry_Alzira: Registre Civil d'Alzira
+          civil_registry_Benidorm: Registre Civil de Benidorm
+          civil_registry_Carlet: Registre Civil de Carlet
+          civil_registry_Castello: Registre Civil de Castelló de la Plana
+          civil_registry_Catarroja: Registre Civil de Catarroja
+          civil_registry_Dénia: Registre Civil de Dénia
+          civil_registry_Elda: Registre Civil d'Elda
+          civil_registry_Elche: Registre Civil d'Elx/Elche
+          civil_registry_Gandia: Registre Civil de Gandia
+          civil_registry_Ibi: Registre Civil d'Ibi
+          civil_registry_Villajoyosa: Registre Civil de Vila Joiosa 
+          civil_registry_Lliria: Registre Civil de Llíria
+          civil_registry_Massamagrell: Registre Civil de Massamagrell
+          civil_registry_Mislata: Registre Civil de Mislata
+          civil_registry_Moncada: Registre Civil de Moncada
+          civil_registry_Novelda: Registre Civil de Novelda
+          civil_registry_Nules: Registre Civil de Nules
+          civil_registry_Ontinyent: Registre Civil d'Ontinyent
+          civil_registry_Orihuela: Registre Civil d'Orihuela
+          civil_registry_Paterna: Registre Civil de Paterna
+          civil_registry_Picassent: Registre Civil de Picassent
+          civil_registry_Quart: Registre Civil de Quart de Poblet
+          civil_registry_Requena: Registre Civil de Requenat
+          civil_registry_Sagunto: Registre Civil de Sagunt
+          civil_registry_San_Vicente: Registre Civil de Sant Vicent del Raspeig
+          civil_registry_Segorbe: Registre Civil de Segorbe
+          civil_registry_Sueca: Registre Civil de Sueca
+          civil_registry_Torrent: Registre Civil de Torrent
+          civil_registry_Torrevieja: Registre Civil de Torrevieja
+          civil_registry_Vila_real: Registre Civil de Vila-real
+          civil_registry_Villena: Registre Civil de Villena
+          civil_registry_Vinaros: Registre Civil de Vinaròs
+          civil_registry_Xativa: Registre Civil de Xàtiva
+          exclusive_civil_registry_1_Alicante: Registre Civil Exclusivo Nº1 Alacant
+          exclusive_civil_registry_1_Valencia: Registre Civil Exclusivo Nº1 València
+          exclusive_civil_registry_2_Alicante: Registre Civil Exclusivo Nº2 Alacant
+          exclusive_civil_registry_2_Valencia: Registre Civil Exclusivo Nº2 València
+          exclusive_civil_registry_3_Valencia: Registre Civil Exclusivo Nº3 València
+          healthcare: Sanitat
+          education: Ensenyança
+          valencian: Valencià (Junta Qualificadora)
+          social_economy: Economia social / Cooperatives
+          work: Treball
+          employment: Ocupació (LABORA)
+          culture: Cultura
+          airports: Aeroports
+          nautical_activities: Activitats nàutiques (exàmens / titulacions)
+          coasts: Costes
+          roads: Carreteres
+          ports: Ports
+          transport: Transports (Exàmens transportistes / targetes transports ...)
+          urban_planning: Urbanisme
+          territorial_policy: Política territorial i paisatge
+          environment: Medi ambient
+          trade: Comerç i consum
+          industry: Indústria, energia i mines
+          innovation: Innovació
+          AVI: AVI (Agència Valenciana de la Innovació) 
+          IVACE: IVACE (Institut Valencià de Competitivitat Empresarial)
+          tourism: Turisme (Turisme Comunitat Valenciana) 
+          agriculture: Agricultura, aigua, ramaderia i pesca 
+          forest_fire_prevention: Prevenció d'incendis forestals
+          entertainment: Espectacles
+      submit: "Envia"
+    success:
+      title: "Gràcies per la seua col·laboració! Rebrà un email amb una còpia del seu missatge."
   proposals:
     create:
       form:

--- a/config/locales/custom/val/mailers.yml
+++ b/config/locales/custom/val/mailers.yml
@@ -164,3 +164,22 @@ val:
     budget_change_active_phases:
       success: "%{budget_name} ha cambiado de la fase '%{previous_phase}' a '%{next_phase}'"
       error: Error al cambiar de fase
+  citizen_opinion_mailer:
+    shared:
+      date: "Data"
+      body: "Pregunta o suggeriment"
+      phone: "Telèfon"
+      email: "Correu electrònic de resposta"
+      topic: "Tema"
+      subject: "Assumpte"
+    confirmation:
+      subject: "Bústia de consultes per al PROP"
+      title: "Confirmació d'enviament del formulari."
+      text: "Gràcies per escriure'ns. Hem rebut el seu missatge."
+      name: "Nombre"
+    notification:
+      subject: "Nou missatge en bústia de la ciutadania sobre TEMA: %{topic}"
+      title: "Nou missatge en bústia de la ciutadania"
+      text: "S'ha rebut un nou missatge en la bústia de la ciutadania amb el següent contingut:"
+      from: "De"
+      citizen_mailbox: "bústia de la ciutadania"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -234,6 +234,9 @@ namespace :admin do
       end
     end
 
+    # get :citizenship_mailbox, to: "citizen_opinions#index"
+    resources :citizen_opinions, path: "citizenship_mailbox", only: [:index]
+
     resources :newsletters do
       member do
         post :deliver

--- a/config/routes/custom.rb
+++ b/config/routes/custom.rb
@@ -50,6 +50,8 @@ constraints lambda { |request| !Rails.application.multitenancy_management_mode? 
     end
   end
 
+  resources :citizen_opinions, only: [:new, :create]
+
   namespace :admin do
     resources :legislators, only: [:index, :create, :destroy] do
       get :search, on: :collection

--- a/db/migrate/20251007163000_create_citizen_opinions.rb
+++ b/db/migrate/20251007163000_create_citizen_opinions.rb
@@ -7,7 +7,7 @@ class CreateCitizenOpinions < ActiveRecord::Migration[6.1]
       t.string :subject
       t.text :body, null: false
       t.string :email, null: false
-      
+
       t.timestamps
     end
   end

--- a/db/migrate/20251007163000_create_citizen_opinions.rb
+++ b/db/migrate/20251007163000_create_citizen_opinions.rb
@@ -1,0 +1,14 @@
+class CreateCitizenOpinions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :citizen_opinions do |t|
+      t.string :topic, null: false
+      t.string :name
+      t.string :phone
+      t.string :subject
+      t.text :body, null: false
+      t.string :email, null: false
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_26_103703) do
+ActiveRecord::Schema[7.0].define(version: 2025_10_07_163000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -441,6 +441,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_26_103703) do
     t.jsonb "sent_at_dates", default: []
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "citizen_opinions", force: :cascade do |t|
+    t.string "topic", null: false
+    t.string "name"
+    t.string "phone"
+    t.string "subject"
+    t.text "body", null: false
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "ckeditor_assets", id: :serial, force: :cascade do |t|

--- a/spec/controllers/custom/citizen_opinions_controller_spec.rb
+++ b/spec/controllers/custom/citizen_opinions_controller_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe CitizenOpinionsController do
   describe "GET #new" do
     before { get :new }
-    
-    it "returns http success" do  
+
+    it "returns http success" do
       expect(response).to be_successful
     end
   end
@@ -33,19 +33,19 @@ RSpec.describe CitizenOpinionsController do
       it "sends notification and confirmation emails" do
         notification_mailer = double(deliver_later: true)
         confirmation_mailer = double(deliver_later: true)
-        
+
         expect(CitizenOpinionMailer).to receive(:notification)
           .and_return(notification_mailer)
         expect(CitizenOpinionMailer).to receive(:confirmation)
           .and_return(confirmation_mailer)
-        
+
         post :create, params: { citizen_opinion: valid_attributes }
       end
     end
 
     context "with invalid params" do
       before { post :create, params: { citizen_opinion: invalid_attributes } }
-      
+
       it "does not create a new citizen opinion" do
         expect do
           post :create, params: { citizen_opinion: invalid_attributes }
@@ -59,7 +59,7 @@ RSpec.describe CitizenOpinionsController do
       it "does not send any emails" do
         expect(CitizenOpinionMailer).not_to receive(:notification)
         expect(CitizenOpinionMailer).not_to receive(:confirmation)
-        
+
         post :create, params: { citizen_opinion: invalid_attributes }
       end
     end

--- a/spec/controllers/custom/citizen_opinions_controller_spec.rb
+++ b/spec/controllers/custom/citizen_opinions_controller_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe CitizenOpinionsController do
+  describe "GET #new" do
+    before { get :new }
+    
+    it "returns http success" do  
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST #create" do
+    let(:valid_attributes) { build(:citizen_opinion).attributes }
+
+    let(:invalid_attributes) do
+      {
+        topic: "",
+        body: "",
+        email: "invalid-email"
+      }
+    end
+
+    context "with valid params" do
+      it "creates a new citizen opinion and redirects" do
+        expect do
+          post :create, params: { citizen_opinion: valid_attributes }
+        end.to change(CitizenOpinion, :count).by(1)
+
+        expect(response).to redirect_to(new_citizen_opinion_path)
+        expect(flash[:notice]).to be_present
+      end
+
+      it "sends notification and confirmation emails" do
+        notification_mailer = double(deliver_later: true)
+        confirmation_mailer = double(deliver_later: true)
+        
+        expect(CitizenOpinionMailer).to receive(:notification)
+          .and_return(notification_mailer)
+        expect(CitizenOpinionMailer).to receive(:confirmation)
+          .and_return(confirmation_mailer)
+        
+        post :create, params: { citizen_opinion: valid_attributes }
+      end
+    end
+
+    context "with invalid params" do
+      before { post :create, params: { citizen_opinion: invalid_attributes } }
+      
+      it "does not create a new citizen opinion" do
+        expect do
+          post :create, params: { citizen_opinion: invalid_attributes }
+        end.not_to change(CitizenOpinion, :count)
+      end
+
+      it "returns unprocessable entity status" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "does not send any emails" do
+        expect(CitizenOpinionMailer).not_to receive(:notification)
+        expect(CitizenOpinionMailer).not_to receive(:confirmation)
+        
+        post :create, params: { citizen_opinion: invalid_attributes }
+      end
+    end
+  end
+end

--- a/spec/factories/custom/citizen_opinions.rb
+++ b/spec/factories/custom/citizen_opinions.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :citizen_opinion do
+    topic { Custom::CitizenOpinionsHelper::TOPIC_GROUPS[:general][0] }
+    name { Faker::Name.name }
+    phone { Faker::PhoneNumber.phone_number }
+    subject { Faker::Lorem.sentence }
+    body { Faker::Lorem.paragraph }
+    email { Faker::Internet.email }
+  end
+end

--- a/spec/models/custom/citizen_opinion_spec.rb
+++ b/spec/models/custom/citizen_opinion_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe CitizenOpinion do
+  let(:citizen_opinion) { build(:citizen_opinion) }
+
+  describe "validations" do
+    it "is valid with all required attributes" do
+      expect(citizen_opinion).to be_valid
+    end
+
+    describe "#topic" do
+      it "is not valid without a topic" do
+        citizen_opinion.topic = nil
+        expect(citizen_opinion).not_to be_valid
+      end
+
+      it "is not valid with an empty topic" do
+        citizen_opinion.topic = ""
+        expect(citizen_opinion).not_to be_valid
+      end
+    end
+
+    describe "#body" do
+      it "is not valid without a body" do
+        citizen_opinion.body = nil
+        expect(citizen_opinion).not_to be_valid
+      end
+
+      it "is not valid with an empty body" do
+        citizen_opinion.body = ""
+        expect(citizen_opinion).not_to be_valid
+      end
+    end
+
+    describe "#email" do
+      it "is not valid without an email" do
+        citizen_opinion.email = nil
+        expect(citizen_opinion).not_to be_valid
+      end
+
+      it "is not valid with an empty email" do
+        citizen_opinion.email = ""
+        expect(citizen_opinion).not_to be_valid
+      end
+
+      it "is not valid with an invalid email format" do
+        invalid_emails = ["test", "test@", "@test.com", "test@test", "test.com"]
+        
+        invalid_emails.each do |email|
+          citizen_opinion.email = email
+          expect(citizen_opinion).not_to be_valid
+        end
+      end
+
+      it "is valid with a valid email format" do
+        valid_emails = ["test@test.com", "user.name@domain.com", "user+label@domain.co.uk"]
+        
+        valid_emails.each do |email|
+          citizen_opinion.email = email
+          expect(citizen_opinion).to be_valid
+        end
+      end
+    end
+  end
+
+  describe "pagination" do
+    it "paginates with 25 records per page" do
+      expect(CitizenOpinion.default_per_page).to eq(25)
+    end
+  end
+end

--- a/spec/models/custom/citizen_opinion_spec.rb
+++ b/spec/models/custom/citizen_opinion_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CitizenOpinion do
 
       it "is not valid with an invalid email format" do
         invalid_emails = ["test", "test@", "@test.com", "test@test", "test.com"]
-        
+
         invalid_emails.each do |email|
           citizen_opinion.email = email
           expect(citizen_opinion).not_to be_valid
@@ -54,7 +54,7 @@ RSpec.describe CitizenOpinion do
 
       it "is valid with a valid email format" do
         valid_emails = ["test@test.com", "user.name@domain.com", "user+label@domain.co.uk"]
-        
+
         valid_emails.each do |email|
           citizen_opinion.email = email
           expect(citizen_opinion).to be_valid


### PR DESCRIPTION
## Objectives

> Replicar el formulario institucional “Mi opinión cuenta” ([ver ejemplo](https://www.gva.es/es/web/atencio_ciutadania/inicio/mi_opinion_cuenta/mop_envio_mail_prop))
> Envío al mismo endpoint/buzón institucional. PENDIENTE DE CONFIRMACIÓN DE EMAIL (Añadir a secret tras el despliegue)
> Integración visual con la identidad de GVA Participa.
> Confirmación automática al remitente.
> Registro interno para trazabilidad (backoffice).

## Visual Changes

> <img width="1210" height="1298" alt="image" src="https://github.com/user-attachments/assets/0531dbfc-69d9-4a7a-87fc-a1639b3442f0" />
> <img width="840" height="811" alt="image" src="https://github.com/user-attachments/assets/3b29d687-bfce-4186-b11d-6926eb2b0e39" />
> <img width="847" height="861" alt="image" src="https://github.com/user-attachments/assets/79c9424d-bd9f-42cc-a802-90ff9e4aeaf4" />
> <img width="2502" height="1319" alt="image" src="https://github.com/user-attachments/assets/6a1b11cf-4c06-4e18-9b2c-c1636b992674" />

## Notes

> En el despliegue hay que añadir el secret:
```
citizen_opinions_mail_recipient: "aclavijo@usabi.es"
```
