### PR TITLE
fix: mejorar mensajes de error de login y registro para mayor claridad

### DIFF
--- a/config/locales/custom/es/devise.yml
+++ b/config/locales/custom/es/devise.yml
@@ -14,18 +14,18 @@ es:
     failure:
       already_authenticated: "Ya has iniciado sesión."
       inactive: "Tu cuenta aún no ha sido activada."
-      invalid: "%{authentication_keys} o contraseña inválidos."
-      locked: "Tu cuenta ha sido bloqueada."
-      last_attempt: "Tienes un último intento antes de que tu cuenta sea bloqueada."
+      invalid: "El correo electrónico o la contraseña no son correctos. Por favor, revísalos e inténtalo de nuevo."
+      locked: "Tu cuenta ha sido bloqueada por demasiados intentos fallidos. Revisa tu correo electrónico para desbloquearla."
+      last_attempt: "Atención: este es tu último intento. Si la contraseña es incorrecta, tu cuenta quedará bloqueada."
       default: "Error al intentar iniciar sesión"
       database: "Ocurrió error en la base de datos"
       server: "Ocurrió error en el servidor"
       no_backend_roles: "Tu cuenta no tiene roles asignados."
       no_codeper_email: "Tu cuenta no es correo GVA o no tiene codper asignado."
-      not_found_in_database: "%{authentication_keys} o contraseña inválidos."
-      timeout: "Tu sesión ha expirado, por favor inicia sesión nuevamente para continuar."
-      unauthenticated: "Necesitas iniciar sesión o registrarte para continuar."
-      unconfirmed: "Para continuar, por favor pulsa en el enlace de confirmación que hemos enviado a tu cuenta de correo."
+      not_found_in_database: "El correo electrónico o la contraseña no son correctos. Por favor, revísalos e inténtalo de nuevo."
+      timeout: "Tu sesión ha expirado. Por favor, vuelve a iniciar sesión para continuar."
+      unauthenticated: "Necesitas identificarte para continuar. Por favor, inicia sesión o regístrate."
+      unconfirmed: "Confirma tu cuenta antes de continuar. Revisa tu bandeja de entrada (también la carpeta de spam) y haz clic en el enlace que te hemos enviado."
     mailer:
       confirmation_instructions:
         subject: "Instrucciones de confirmación"
@@ -47,7 +47,7 @@ es:
       signed_up: "¡Bienvenido! Has sido identificado."
       signed_up_but_inactive: "Te has registrado correctamente, pero no has podido iniciar sesión porque tu cuenta no ha sido activada."
       signed_up_but_locked: "Te has registrado correctamente, pero no has podido iniciar sesión porque tu cuenta está bloqueada."
-      signed_up_but_unconfirmed: "Se te ha enviado un mensaje con un enlace de confirmación. Por favor visita el enlace para activar tu cuenta."
+      signed_up_but_unconfirmed: "Ya casi está. Te hemos enviado un correo electrónico con un enlace de confirmación. Revisa tu bandeja de entrada (también la carpeta de spam) y haz clic en el enlace para activar tu cuenta."
       update_needs_confirmation: "Has actualizado tu cuenta correctamente, sin embargo necesitamos verificar tu nueva cuenta de correo. Por favor revisa tu correo electrónico y visita el enlace para finalizar la confirmación de tu nueva dirección de correo electrónico."
       updated: "Has actualizado tu cuenta correctamente."
     sessions:
@@ -70,6 +70,6 @@ es:
       not_found: "no se ha encontrado."
       not_locked: "no estaba bloqueado."
       not_saved:
-        one: "1 error impidió que este %{resource} fuera guardado. Por favor revisa los campos marcados para saber cómo corregirlos:"
-        other: "%{count} errores impidieron que este %{resource} fuera guardado. Por favor revisa los campos marcados para saber cómo corregirlos:"
+        one: "Hay un error que impide guardar los cambios. Revisa el campo marcado para corregirlo:"
+        other: "Hay %{count} errores que impiden guardar los cambios. Revisa los campos marcados para corregirlos:"
       equal_to_current_password: "debe ser diferente a la contraseña actual"

--- a/config/locales/custom/es/devise_view.yml
+++ b/config/locales/custom/es/devise_view.yml
@@ -9,7 +9,7 @@ es:
         instructions: Vamos a proceder a confirmar la cuenta con el email <b>%{email}</b>
         new_password_confirmation_label: Repite la clave de nuevo
         new_password_label: Nueva clave de acceso
-        please_set_password: Por favor introduce una nueva clave de acceso para su cuenta (te permitirá hacer login con el email de más arriba)
+        please_set_password: Por favor, introduce una nueva contraseña para tu cuenta (la usarás para iniciar sesión con el correo de más arriba)
         submit: Confirmar
         title: Confirmar mi cuenta
     mailer:
@@ -27,7 +27,7 @@ es:
         title: Cambia tu contraseña
       unlock_instructions:
         hello: Hola
-        info_text: Tu cuenta ha sido bloqueada debido a un excesivo número de intentos fallidos de alta.
+        info_text: Tu cuenta ha sido bloqueada debido a demasiados intentos fallidos de inicio de sesión.
         instructions_text: "Sigue el siguiente enlace para desbloquear tu cuenta:"
         title: Tu cuenta ha sido bloqueada
         unlock_link: Desbloquear mi cuenta
@@ -118,8 +118,8 @@ es:
           privacy_terms: Política de protección de datos
           terms_title: Al registrarte aceptas las condiciones de uso y protección de datos
           title: Registrarse
-          username_is_available: Nombre de persona usuaria disponible
-          username_is_not_available: Nombre de persona usuaria ya existente
+          username_is_available: "Este nombre de usuario está disponible."
+          username_is_not_available: "Este nombre de usuario ya está en uso. Por favor, elige otro."
           username_label: Nombre de persona usuaria
           username_note: Nombre público que aparecerá en tus publicaciones
         success:

--- a/config/locales/custom/val/devise.yml
+++ b/config/locales/custom/val/devise.yml
@@ -14,18 +14,18 @@ val:
     failure:
       already_authenticated: "Ja has iniciat sessió."
       inactive: "El teu compte encara no ha sigut activat."
-      invalid: "%{authentication_keys} o contrasenya invàlids."
-      locked: "El teu compte ha segut bloquejat."
-      last_attempt: "Tens un últim intent abans que el teu compte siga bloquejat."
+      invalid: "El correu electrònic o la contrasenya no són correctes. Si us plau, revisa'ls i torna-ho a intentar."
+      locked: "El teu compte ha sigut bloquejat per massa intents fallits. Revisa el teu correu electrònic per a desbloquejar-lo."
+      last_attempt: "Atenció: aquest és el teu últim intent. Si la contrasenya és incorrecta, el teu compte quedarà bloquejat."
       default: "Error en intentar iniciar sessió"
       database: "Va ocórrer error en la base de dades"
       server: "Va ocórrer error en el servidor"
       no_backend_roles: "El teu compte no té rols assignats."
       no_codeper_email: "El teu compte no és correu GVA o no tens codper assignat."
-      not_found_in_database: "%{authentication_keys} o contrasenya invàlids."
-      timeout: "La teua sessió ha expirat, per favor inicia sessió novament per a continuar."
-      unauthenticated: "Necessites iniciar sessió o registrar-te per a continuar."
-      unconfirmed: "Per a continuar, per favor prem en l'enllaç de confirmació que hem enviat al teu compte de correu"
+      not_found_in_database: "El correu electrònic o la contrasenya no són correctes. Si us plau, revisa'ls i torna-ho a intentar."
+      timeout: "La teua sessió ha expirat. Si us plau, torna a iniciar sessió per a continuar."
+      unauthenticated: "Necessites identificar-te per a continuar. Si us plau, inicia sessió o registra't."
+      unconfirmed: "Confirma el teu compte abans de continuar. Revisa la teua safata d'entrada (també la carpeta de correu no desitjat) i fes clic en l'enllaç que t'hem enviat."
     mailer:
       confirmation_instructions:
         subject: "Instruccions de confirmació"
@@ -47,7 +47,7 @@ val:
       signed_up: "Benvingut! Has sigut identificat."
       signed_up_but_inactive: "T'has registrat correctament, pero no has pogut iniciar sessió perque el teu compte no ha segut activada."
       signed_up_but_locked: "T'has registrat correctament, però no has pogut iniciar sessió perquè el teu compte està bloquejat."
-      signed_up_but_unconfirmed: "Se t'ha enviat un missatge amb un enllaç de confirmació. Per favor visita l'enllaç per a activar el teu compte."
+      signed_up_but_unconfirmed: "Ja quasi està. T'hem enviat un correu electrònic amb un enllaç de confirmació. Revisa la teua safata d'entrada (també la carpeta de correu no desitjat) i fes clic en l'enllaç per a activar el teu compte."
       update_needs_confirmation: "Has actualitzat el teu compte correctament, no obstant açò necessitem verificar el teu nou compte de correu. Per favor revisa el teu correu electrònic i visita l'enllaç per a finalitzar la confirmació de la teua nova adreça de correu electrònica."
       updated: "Has actualitzat el teu compte correctament."
     sessions:
@@ -70,6 +70,6 @@ val:
       not_found: "no s'ha trobat."
       not_locked: "no estava bloquejat."
       not_saved:
-        one: "1 error impedeix salvar este %{resource}. Si us plau verifica els camps marcats per a corregirlos:"
-        other: "%{count} errors impedeixen salvar este %{resource}. Si us plau verifica els camps marcats per a corregirlos:"
+        one: "Hi ha un error que impedeix guardar els canvis. Revisa el camp marcat per a corregir-lo:"
+        other: "Hi ha %{count} errors que impedeixen guardar els canvis. Revisa els camps marcats per a corregir-los:"
       equal_to_current_password: "ha de ser diferent a la contrasenya actual."

--- a/config/locales/custom/val/devise_views.yml
+++ b/config/locales/custom/val/devise_views.yml
@@ -27,7 +27,7 @@ val:
         title: Canvia la teua contrasenya
       unlock_instructions:
         hello: Hola
-        info_text: El teu compte ha segut bloquejat a causa d'un excessiu nombre d'intents fallits d'alta.
+        info_text: El teu compte ha sigut bloquejat a causa de massa intents fallits d'inici de sessió.
         instructions_text: "Segueix el seguent enllaç per a desbloquejar el teu compte:"
         title: El teu compte ha segut bloquejat
         unlock_link: Desbloquejar el meu compte
@@ -51,7 +51,7 @@ val:
         success:
           back_to_index: Entés, tornar a la pàgina principal
           instructions_1: "En breu <b>ens posarem en contacte amb tu</b> per a verificar que realment representes a aquest col·lectiu."
-          instructions_2: <b>revisa el teu correu electrìnic</b>, t’hem enviat un <b>enllaç per a confirmar el teu compte</b>.
+          instructions_2: "Mentrestant, <b>revisa el teu correu electrònic</b>: t’hem enviat un <b>enllaç per a confirmar el teu compte</b>."
           instructions_3: Una vegada confirmat, podràs començar a participar com a col·lectiu no verificat.
           thank_you: Gràcies per registrar el teu col·lectiu en la web. Ara està <b>pendent de verificació</b>.
           title: Registre d'organització / col·lectiu
@@ -118,8 +118,8 @@ val:
           privacy_terms: Política de protecció de dades
           terms_title: "Al registrar-te acceptes les condicions d’ús i protecció de dades"
           title: Registrar-se
-          username_is_available: Nom de persona usuària disponible
-          username_is_not_available: Nom de persona usuària ja existeix
+          username_is_available: "Aquest nom d'usuari està disponible."
+          username_is_not_available: "Aquest nom d'usuari ja està en ús. Si us plau, tria'n un altre."
           username_label: Nom de persona usuària
           username_note: Nom públic que apareixerà en les teues publicacions
         success:

--- a/config/locales/custom/val/general.yml
+++ b/config/locales/custom/val/general.yml
@@ -270,7 +270,7 @@ val:
       name: Facebook
     finish_signup:
       title: "Detalls adicionals del teu compte"
-      username_warning: "Degut a que hem canviat la forma en la que ens conectem amb les xarxes socials i es possible que el teu nom ja aparega com \"ya en us\", inclus si abans podies accedir amb ell. Si es el teu cas, si us plau eligeix un nom d'usuari distint."
+      username_warning: "Hem canviat la forma de connectar-nos amb les xarxes socials i és possible que el teu nom d'usuari aparega com \"ja en ús\", fins i tot si abans podies accedir amb ell. Si és el teu cas, si us plau, tria un nom d'usuari diferent."
     google_oauth2:
       sign_in: Entra amb Google
       sign_up: Regístrat amb Google


### PR DESCRIPTION
Mensajes de fallo de autenticación, cuenta bloqueada, sin confirmar y formulario de registro reescritos en lenguaje más cercano al usuario. Corregido bug en val/general.yml con texto en castellano incrustado.


