### PR TITLE
fix: corregir enlaces y filtro de polls en panel de administración

### DIFF
--- a/app/components/custom/admin/dashboard/legislation_processes_component.html.erb
+++ b/app/components/custom/admin/dashboard/legislation_processes_component.html.erb
@@ -16,7 +16,7 @@
             <ul class="dashboard-list">
               <% @preview_processes.each do |process| %>
                 <li>
-                  <span class="list-title"><%= link_to process.title, admin_legislation_process_path(process) %></span>
+                  <span class="list-title"><%= link_to process.title, edit_admin_legislation_process_path(process) %></span>
                   <span class="list-phases">
                     <% if process.debate_phase.enabled? && process.debate_phase.open? %>
                       <span class="phase-tag active">
@@ -50,7 +50,7 @@
             <ul class="dashboard-list">
               <% @public_processes.each do |process| %>
                 <li>
-                  <span class="list-title"><%= link_to process.title, admin_legislation_process_path(process) %></span>
+                  <span class="list-title"><%= link_to process.title, edit_admin_legislation_process_path(process) %></span>
                   <span class="list-phases">
                     <% if process.allegations_phase.enabled? && process.allegations_phase.open? %>
                       <span class="phase-tag active">

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < Admin::BaseController
   def index
     @debates = ::Debate.limit(5)
-    @polls = ::Poll.current_or_recounting.limit(5)
+    @polls = ::Poll.published.current_or_recounting.limit(5)
     @budgets = ::Budget.published.order(created_at: :desc).limit(3)
     @proposals = ::Proposal.limit(5)
     @preview_processes = Legislation::Process.published.active.preview_phase.order(start_date: :asc).limit(10)


### PR DESCRIPTION
- Legislation processes ahora enlazan a la ruta edit en lugar de show
- Polls en el dashboard filtran por published para ocultar votaciones no activadas
